### PR TITLE
[25.07.31 / TASK-237] Modify - 주간 인사이트 어드민 뷰에 변경된 스키마 반영

### DIFF
--- a/insight/admin/user_weekly_trend_admin.py
+++ b/insight/admin/user_weekly_trend_admin.py
@@ -23,7 +23,7 @@ class UserWeeklyTrendAdmin(
         "created_at",
     )
     list_filter = ("is_processed", "week_start_date")
-    search_fields = ("user__email", "insight")
+    search_fields = ("user__username", "insight")
     readonly_fields = (
         "processed_at",
         "formatted_insight",
@@ -68,7 +68,7 @@ class UserWeeklyTrendAdmin(
         return format_html(
             '<a href="{}" target="_blank">{}</a>',
             user_url,
-            obj.user.email or f"사용자 {obj.user.id}",
+            obj.user.username or f"사용자 {obj.user.id}",
         )
 
     @admin.action(description="선택된 항목을 처리 완료로 표시하기")

--- a/insight/tests/conftest.py
+++ b/insight/tests/conftest.py
@@ -230,3 +230,13 @@ def inactive_user_weekly_trend(
         week_end_date=week_end,
         insight=insight_dict,
     )
+
+
+@pytest.fixture
+def empty_insight_weekly_trend(db):
+    """빈 인사이트를 가진 주간 트렌드"""
+    week_start, week_end = get_previous_week_range()
+
+    return WeeklyTrend.objects.create(
+        week_start_date=week_start, week_end_date=week_end, insight={}
+    )

--- a/insight/tests/conftest.py
+++ b/insight/tests/conftest.py
@@ -230,13 +230,3 @@ def inactive_user_weekly_trend(
         week_end_date=week_end,
         insight=insight_dict,
     )
-
-
-@pytest.fixture
-def empty_insight_weekly_trend(db):
-    """빈 인사이트를 가진 주간 트렌드"""
-    week_start, week_end = get_previous_week_range()
-
-    return WeeklyTrend.objects.create(
-        week_start_date=week_start, week_end_date=week_end, insight={}
-    )

--- a/insight/tests/test_json_preview_mixin_admin.py
+++ b/insight/tests/test_json_preview_mixin_admin.py
@@ -18,6 +18,12 @@ class TestJsonPreviewMixin:
         # 길이 제한으로 인해 원본보다 짧은지 확인
         assert len(preview) < len(str(weekly_trend.insight))
 
+    def test_get_json_preview_empty(self, empty_insight_weekly_trend):
+        """빈 JSON 데이터에 대한 get_json_preview 테스트"""
+        mixin = JsonPreviewMixin()
+        preview = mixin.get_json_preview(empty_insight_weekly_trend, "insight")
+        assert preview == "-"
+
     def test_formatted_insight_weekly_trend(
         self, weekly_trend: WeeklyTrend, sample_trend_analysis
     ):
@@ -49,7 +55,7 @@ class TestJsonPreviewMixin:
     def test_formatted_insight_user_weekly_trend_with_reminder(
         self, inactive_user_weekly_trend: UserWeeklyTrend
     ):
-        """UserWeeklyTrend의 formatted_insight 테스트"""
+        """주간 글 미작성 UserWeeklyTrend의 formatted_insight 테스트"""
         mixin = JsonPreviewMixin()
         result = mixin.formatted_insight(inactive_user_weekly_trend)
 
@@ -58,3 +64,9 @@ class TestJsonPreviewMixin:
         assert "트렌드 분석" not in result
         assert "핵심 키워드" not in result
         assert "작성 게시글 요약" not in result
+
+    def test_formatted_insight_empty(self, empty_insight_weekly_trend):
+        """빈 인사이트 데이터에 대한 formatted_insight 테스트"""
+        mixin = JsonPreviewMixin()
+        result = mixin.formatted_insight(empty_insight_weekly_trend)
+        assert result == "-"

--- a/insight/tests/test_json_preview_mixin_admin.py
+++ b/insight/tests/test_json_preview_mixin_admin.py
@@ -18,12 +18,6 @@ class TestJsonPreviewMixin:
         # 길이 제한으로 인해 원본보다 짧은지 확인
         assert len(preview) < len(str(weekly_trend.insight))
 
-    def test_get_json_preview_empty(self, empty_insight_weekly_trend):
-        """빈 JSON 데이터에 대한 get_json_preview 테스트"""
-        mixin = JsonPreviewMixin()
-        preview = mixin.get_json_preview(empty_insight_weekly_trend, "insight")
-        assert preview == "-"
-
     def test_formatted_insight_weekly_trend(
         self, weekly_trend: WeeklyTrend, sample_trend_analysis
     ):
@@ -44,6 +38,7 @@ class TestJsonPreviewMixin:
         mixin = JsonPreviewMixin()
         result = mixin.formatted_insight(user_weekly_trend)
 
+        assert "사용자 주간 통계" in result
         assert "트렌드 분석" in result
         assert "핵심 키워드" in result
         for keyword in sample_trend_analysis.hot_keywords:
@@ -51,8 +46,15 @@ class TestJsonPreviewMixin:
         assert "작성 게시글 요약" in result
         assert "Django 모델 최적화하기" in result
 
-    def test_formatted_insight_empty(self, empty_insight_weekly_trend):
-        """빈 인사이트 데이터에 대한 formatted_insight 테스트"""
+    def test_formatted_insight_user_weekly_trend_with_reminder(
+        self, inactive_user_weekly_trend: UserWeeklyTrend
+    ):
+        """UserWeeklyTrend의 formatted_insight 테스트"""
         mixin = JsonPreviewMixin()
-        result = mixin.formatted_insight(empty_insight_weekly_trend)
-        assert result == "-"
+        result = mixin.formatted_insight(inactive_user_weekly_trend)
+
+        assert "리마인더" in result
+        assert "사용자 주간 통계" in result
+        assert "트렌드 분석" not in result
+        assert "핵심 키워드" not in result
+        assert "작성 게시글 요약" not in result

--- a/insight/tests/test_user_weekly_trend_admin.py
+++ b/insight/tests/test_user_weekly_trend_admin.py
@@ -29,7 +29,7 @@ class TestUserWeeklyTrendAdmin:
             )
             result = user_weekly_trend_admin.user_info(user_weekly_trend)
 
-        assert user_weekly_trend.user.email in result
+        assert user_weekly_trend.user.username in result
 
     def test_week_range(
         self, user_weekly_trend_admin, user_weekly_trend: UserWeeklyTrend

--- a/templates/insights/insight_preview.html
+++ b/templates/insights/insight_preview.html
@@ -1,4 +1,14 @@
 <div class="module aligned">
+    {% if user and insight.user_weekly_stats %}
+        <h2 style="margin-top: 20px;">사용자 주간 통계</h2>
+        <div style="margin-left: 15px;">
+            <p><strong>전체 게시글 수:</strong> {{ insight.user_weekly_stats.posts }}</p>
+            <p><strong>새 게시글 수:</strong> {{ insight.user_weekly_stats.new_posts }}</p>
+            <p><strong>조회수 증가:</strong> {{ insight.user_weekly_stats.views }}</p>
+            <p><strong>좋아요 증가:</strong> {{ insight.user_weekly_stats.likes }}</p>
+        </div>
+    {% endif %}
+
     {% if insight.trend_analysis %}
         <h2 style="margin-top: 10px;">트렌드 분석</h2>
         <div style="margin-left: 15px;">
@@ -28,16 +38,27 @@
 
     {% if insight.trending_summary %}
         <h2 style="margin-top: 20px;">{% if user %}작성 게시글 요약{% else %}트렌딩 요약{% endif %}</h2>
-        {% for summary in insight.trending_summary %}
+        {% for item in insight.trending_summary %}
             <div style="margin: 15px 0; padding-left: 15px; border-left: 3px solid #ddd;">
-                <h3 style="margin-bottom: 5px;">{{ forloop.counter }}. {{ summary.title }}</h3>
-                <p style="line-height: 1.5; margin-bottom: 8px;">{{ summary.summary }}</p>
-                {% if summary.key_points %}
-                    <p><strong>핵심 포인트:</strong> {{ summary.key_points|join:", " }}</p>
+                <h3 style="margin-bottom: 5px;">{{ forloop.counter }}. {{ item.title }}</h3>
+                <p style="line-height: 1.5; margin-bottom: 8px;">{{ item.summary }}</p>
+                {% if item.key_points %}
+                    <p><strong>핵심 키워드:</strong> {{ item.key_points|join:", " }}</p>
                 {% endif %}
+                    <p><strong>작성자:</strong> {{ item.username }}</p>
+                    <p><strong>URL:</strong> <a href="https://velog.io/@{{item.username}}/{{item.slug}}" target="_blank">https://velog.io/@{{item.username}}/{{item.slug}}</a></p>
+                    {% if item.thumbnail %}
+                        <p><strong>썸네일:</strong> <img src="{{item.thumbnail}}" alt="썸네일" style="width: 150px;"></p>
+                    {% endif %}
             </div>
         {% endfor %}
-    {% else %}
-        <p>요약 데이터 없음</p>
+    {% endif %}
+
+    {% if user and insight.user_weekly_reminder %}
+        <h2 style="margin-top: 20px;">리마인더</h2>
+        <div style="margin-left: 15px;">
+            <p><strong>마지막 작성 글:</strong> {{ insight.user_weekly_reminder.title }}</p>
+            <p><strong>마지막 작성일:</strong> {{ insight.user_weekly_reminder.days_ago }}일 전</p>
+        </div>
     {% endif %}
 </div>


### PR DESCRIPTION
## 🔥 변경 사항

개발하며 변경된 인사이트 스키마를 어드민 뷰에 적용하였습니다.
자세한 건 스크린샷을 참고해주세요!!

## 🏷 관련 이슈
- X

## 📸 스크린샷 (UI 변경 시 필수)

<img width="1762" height="692" alt="image" src="https://github.com/user-attachments/assets/6e0f8585-0f0a-481c-909b-287d8becfc6f" />
기존에 이메일 값이었던 사용자 컬럼을 username 값으로 수정

<img width="1920" height="1120" alt="image" src="https://github.com/user-attachments/assets/7f121315-8f91-46d6-a135-d7a95a3e55ea" />
주간 인사이트) 추가된 컬럼인 작성자, URL, 썸네일 추가

<img width="1392" height="648" alt="image" src="https://github.com/user-attachments/assets/ad85515b-9b37-4ecd-8d87-dbbe2679e892" />
개인 인사이트) 주간 통계, 리마인더 표시

<img width="2290" height="1662" alt="image" src="https://github.com/user-attachments/assets/e61d63cf-5bbb-4126-a150-b52bd12d2761" />
개인 인사이트) 공통과 같이 인사이트에 컬럼 추가, 주간 통계 표시

## 📌 체크리스트
- [x] 기능이 정상적으로 동작하는지 테스트 완료
- [x] 코드 스타일 가이드 준수 여부 확인
- [x] 관련 문서 업데이트 완료 (필요 시)
