### PR TITLE
[25.09.20 / TASK-255] Feature - admin mail template 업데이트 및 주간 배치 cron

### DIFF
--- a/.github/workflows/run-weekly-analysis.yaml
+++ b/.github/workflows/run-weekly-analysis.yaml
@@ -2,8 +2,9 @@ name: Weekly Analysis Batch
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: "*/50 * * * *"
+  schedule:
+    # 매주 월요일 오전 7시 실행
+    - cron: "0 7 * * 1"
 
 jobs:
   weekly-trend-analysis-batch:

--- a/.github/workflows/run-weekly-newsletter.yaml
+++ b/.github/workflows/run-weekly-newsletter.yaml
@@ -2,8 +2,9 @@ name: Weekly Newsletter Batch
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: "*/50 * * * *"
+  schedule:
+    # 매주 월요일 오전 9시 30분 실행
+    - cron: "30 9 * * 1"
 
 jobs:
   weekly-newsletter-batch:

--- a/insight/admin/user_weekly_trend_admin.py
+++ b/insight/admin/user_weekly_trend_admin.py
@@ -1,23 +1,31 @@
+import json
+from html import escape
+
 from django.contrib import admin
 from django.db.models import QuerySet
 from django.http import HttpRequest
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 
-from insight.admin import BaseTrendAdminMixin, JsonPreviewMixin
-from insight.models import UserWeeklyTrend
-from utils.utils import get_local_now
+from insight.admin.base_admin import BaseTrendAdminMixin
+from insight.models import (
+    UserWeeklyTrend,
+    WeeklyTrend,
+    WeeklyTrendInsight,
+    WeeklyUserTrendInsight,
+)
+from utils.utils import from_dict, get_local_now
 
 
 @admin.register(UserWeeklyTrend)
-class UserWeeklyTrendAdmin(
-    admin.ModelAdmin, JsonPreviewMixin, BaseTrendAdminMixin
-):
+class UserWeeklyTrendAdmin(admin.ModelAdmin, BaseTrendAdminMixin):
     list_display = (
         "id",
         "user_info",
         "week_range",
-        "insight_preview",
+        "summarize_insight",
         "is_processed_colored",
         "processed_at_formatted",
         "created_at",
@@ -26,7 +34,8 @@ class UserWeeklyTrendAdmin(
     search_fields = ("user__username", "insight")
     readonly_fields = (
         "processed_at",
-        "formatted_insight",
+        "render_full_preview",
+        "formatted_insight_json",
     )
     raw_id_fields = ("user",)
 
@@ -38,10 +47,17 @@ class UserWeeklyTrendAdmin(
             },
         ),
         (
-            "인사이트 데이터",
+            "뉴스레터 미리보기",
             {
-                "fields": ("formatted_insight",),
-                "classes": ("wide", "extrapretty"),
+                "fields": ("render_full_preview",),
+                "classes": ("wide",),
+            },
+        ),
+        (
+            "원본 데이터 (JSON)",
+            {
+                "fields": ("formatted_insight_json",),
+                "classes": ("wide", "collapse"),
             },
         ),
         (
@@ -70,6 +86,109 @@ class UserWeeklyTrendAdmin(
             user_url,
             obj.user.username or f"사용자 {obj.user.id}",
         )
+
+    @admin.display(description="인사이트 요약")
+    def summarize_insight(self, obj: UserWeeklyTrend):
+        if not isinstance(obj.insight, dict):
+            return "데이터 없음"
+
+        summary_parts = []
+        stats = obj.insight.get("user_weekly_stats")
+        if stats:
+            summary_parts.append(
+                f"조회수: {stats.get('views', 0)}, 새글: {stats.get('new_posts', 0)}"
+            )
+
+        summary = obj.insight.get("trending_summary", [])
+        if summary and isinstance(summary, list) and summary[0].get("title"):
+            summary_parts.append(f"신규글: {summary[0]['title'][:20]}...")
+
+        return " | ".join(summary_parts) if summary_parts else "요약 정보 없음"
+
+    @admin.display(description="뉴스레터 템플릿")
+    def render_full_preview(self, obj: UserWeeklyTrend):
+        if not obj.insight:
+            return "No insight data to preview."
+        try:
+            # 공통 주간 트렌드 데이터 조회
+            weekly_trend = WeeklyTrend.objects.filter(
+                week_start_date=obj.week_start_date,
+                week_end_date=obj.week_end_date,
+            ).first()
+
+            if not weekly_trend or not weekly_trend.insight:
+                weekly_trend_html = "<p><strong>경고:</strong> 해당 주차의 공통 WeeklyTrend를 찾을 수 없거나 데이터가 없습니다.</p>"
+            else:
+                weekly_trend_insight = from_dict(
+                    WeeklyTrendInsight, weekly_trend.insight
+                )
+                weekly_trend_html = render_to_string(
+                    "insights/weekly_trend.html",
+                    {"insight": weekly_trend_insight.to_dict()},
+                )
+
+            # 사용자 주간 트렌드 렌더링
+            user_weekly_insight = from_dict(
+                WeeklyUserTrendInsight, obj.insight
+            )
+            user_weekly_trend_html = render_to_string(
+                "insights/user_weekly_trend.html",
+                {
+                    "user": {
+                        "username": obj.user.username if obj.user else "N/A"
+                    },
+                    "insight": user_weekly_insight.to_dict(),
+                },
+            )
+
+            # 최종 뉴스레터 렌더링
+            final_html = render_to_string(
+                "insights/index.html",
+                {
+                    "s_date": obj.week_start_date,
+                    "e_date": obj.week_end_date,
+                    "is_expired_token_user": False,
+                    "weekly_trend_html": weekly_trend_html,
+                    "user_weekly_trend_html": user_weekly_trend_html,
+                },
+            )
+
+            # Admin 페이지 너비 확장을 위한 CSS
+            style = """
+            <style>
+            /* iframe을 감싸는 필드의 너비 확장 */
+            .field-render_full_preview {
+                width: 100% !important;
+                max-width: none !important;
+            }
+            
+            /* Django admin 전체 콘텐츠 영역 확장 */
+            .app-insight.model-weeklytrend .form-row,
+            .app-insight.model-weeklytrend .wide,
+            .app-insight.model-weeklytrend #content-main {
+                max-width: 1400px !important;
+                width: 100% !important;
+            }
+            </style>
+            """
+
+            iframe = f"""
+            <iframe 
+                srcdoc="{escape(final_html)}" 
+                style="width: 100%; min-width: 600px; height: 600px; border: 1px solid #ccc;"
+            ></iframe>
+            """
+
+            return mark_safe(style + iframe)
+        except Exception as e:
+            return f"Error rendering preview: {e}"
+
+    @admin.display(description="Insight JSON")
+    def formatted_insight_json(self, obj: UserWeeklyTrend):
+        if not obj.insight:
+            return "No data"
+        json_str = json.dumps(obj.insight, indent=2, ensure_ascii=False)
+        return mark_safe(f"<pre><code>{escape(json_str)}</code></pre>")
 
     @admin.action(description="선택된 항목을 처리 완료로 표시하기")
     def mark_as_processed(

--- a/insight/admin/weekly_trend_admin.py
+++ b/insight/admin/weekly_trend_admin.py
@@ -1,27 +1,34 @@
+import json
+from html import escape
+
 from django.contrib import admin
 from django.db.models import QuerySet
 from django.http import HttpRequest
+from django.template.loader import render_to_string
+from django.utils.safestring import mark_safe
 
-from insight.admin import BaseTrendAdminMixin, JsonPreviewMixin
-from insight.models import WeeklyTrend
-from utils.utils import get_local_now
+from insight.admin.base_admin import BaseTrendAdminMixin
+from insight.models import WeeklyTrend, WeeklyTrendInsight
+from utils.utils import from_dict, get_local_now
 
 
 @admin.register(WeeklyTrend)
-class WeeklyTrendAdmin(
-    admin.ModelAdmin, JsonPreviewMixin, BaseTrendAdminMixin
-):
+class WeeklyTrendAdmin(admin.ModelAdmin, BaseTrendAdminMixin):
     list_display = (
         "id",
         "week_range",
-        "insight_preview",
+        "summarize_insight",
         "is_processed_colored",
         "processed_at_formatted",
         "created_at",
     )
     list_filter = ("is_processed", "week_start_date")
     search_fields = ("insight",)
-    readonly_fields = ("processed_at", "formatted_insight")
+    readonly_fields = (
+        "processed_at",
+        "render_full_preview",
+        "formatted_insight_json",
+    )
     fieldsets = (
         (
             "기간 정보",
@@ -30,10 +37,17 @@ class WeeklyTrendAdmin(
             },
         ),
         (
-            "인사이트 데이터",
+            "뉴스레터 미리보기",
             {
-                "fields": ("formatted_insight",),
-                "classes": ("wide", "extrapretty"),
+                "fields": ("render_full_preview",),
+                "classes": ("wide",),
+            },
+        ),
+        (
+            "원본 데이터 (JSON)",
+            {
+                "fields": ("formatted_insight_json",),
+                "classes": ("wide", "collapse"),
             },
         ),
         (
@@ -45,6 +59,82 @@ class WeeklyTrendAdmin(
     )
 
     actions = ["mark_as_processed"]
+
+    @admin.display(description="인사이트 요약")
+    def summarize_insight(self, obj: WeeklyTrend):
+        if not isinstance(obj.insight, dict):
+            return "데이터 없음"
+
+        summary_parts = []
+        summary_count = len(obj.insight.get("trending_summary", []))
+        summary_parts.append(f"요약: {summary_count}개")
+
+        keywords = obj.insight.get("trend_analysis", {}).get(
+            "hot_keywords", []
+        )
+        if keywords:
+            summary_parts.append(f"키워드: {', '.join(keywords[:2])}...")
+
+        return " | ".join(summary_parts) if summary_parts else "요약 정보 없음"
+
+    @admin.display(description="뉴스레터 템플릿")
+    def render_full_preview(self, obj: WeeklyTrend):
+        if not obj.insight:
+            return "No insight data to preview."
+        try:
+            weekly_trend_insight = from_dict(WeeklyTrendInsight, obj.insight)
+            context = {"insight": weekly_trend_insight.to_dict()}
+            weekly_trend_html = render_to_string(
+                "insights/weekly_trend.html", context
+            )
+
+            final_html = render_to_string(
+                "insights/index.html",
+                {
+                    "s_date": obj.week_start_date,
+                    "e_date": obj.week_end_date,
+                    "is_expired_token_user": False,
+                    "weekly_trend_html": weekly_trend_html,
+                    "user_weekly_trend_html": None,
+                },
+            )
+
+            # Admin 페이지 너비 확장을 위한 CSS
+            style = """
+            <style>
+            /* iframe을 감싸는 필드의 너비 확장 */
+            .field-render_full_preview {
+                width: 100% !important;
+                max-width: none !important;
+            }
+            
+            /* Django admin 전체 콘텐츠 영역 확장 */
+            .app-insight.model-weeklytrend .form-row,
+            .app-insight.model-weeklytrend .wide,
+            .app-insight.model-weeklytrend #content-main {
+                max-width: 1400px !important;
+                width: 100% !important;
+            }
+            </style>
+            """
+
+            iframe = f"""
+            <iframe 
+                srcdoc="{escape(final_html)}" 
+                style="width: 100%; min-width: 600px; height: 600px; border: 1px solid #ccc;"
+            ></iframe>
+            """
+
+            return mark_safe(style + iframe)
+        except Exception as e:
+            return f"Error rendering preview: {e}"
+
+    @admin.display(description="Insight JSON")
+    def formatted_insight_json(self, obj: WeeklyTrend):
+        if not obj.insight:
+            return "No data"
+        json_str = json.dumps(obj.insight, indent=2, ensure_ascii=False)
+        return mark_safe(f"<pre><code>{escape(json_str)}</code></pre>")
 
     @admin.action(description="선택된 항목을 처리 완료로 표시하기")
     def mark_as_processed(

--- a/insight/tests/conftest.py
+++ b/insight/tests/conftest.py
@@ -1,7 +1,7 @@
 import sys
 import uuid
 from datetime import datetime
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from django.conf import settings
@@ -63,6 +63,7 @@ def weekly_trend_admin(admin_site):
 
 @pytest.fixture
 def user_weekly_trend_admin(admin_site):
+    """UserWeeklyTrendAdmin 인스턴스"""
     return UserWeeklyTrendAdmin(UserWeeklyTrend, admin_site)
 
 
@@ -242,6 +243,7 @@ def empty_insight_weekly_trend(db):
         week_start_date=week_start, week_end_date=week_end, insight={}
     )
 
+
 @pytest.fixture
 def mock_post():
     """테스트용 게시글 목록 응답 (get_trending_posts 용)"""
@@ -255,10 +257,12 @@ def mock_post():
         url_slug="test",
     )
 
+
 @pytest.fixture
 def mock_post_detail():
     """테스트용 게시글 본문 응답 (get_post 용)"""
     return MagicMock(body="test content")
+
 
 @pytest.fixture
 def mock_context(mock_post, mock_post_detail):
@@ -274,7 +278,9 @@ def mock_context(mock_post, mock_post_detail):
     mock_context.week_end = datetime(2025, 7, 27)
     return mock_context
 
+
 @pytest.fixture
 def trending_post_data(mock_post, mock_post_detail):
     from insight.tasks.weekly_trend_analysis import TrendingPostData
+
     return TrendingPostData(post=mock_post, body=mock_post_detail.body)

--- a/insight/tests/test_user_weekly_trend_admin.py
+++ b/insight/tests/test_user_weekly_trend_admin.py
@@ -1,51 +1,378 @@
-from unittest.mock import patch
+# poetry run pytest insight/tests/test_user_weekly_trend_admin.py -v
+from unittest.mock import MagicMock, patch
 
 import pytest
+from django.http import HttpRequest
 
-from insight.models import UserWeeklyTrend
-from utils.utils import get_local_now
+from insight.models import UserWeeklyTrend, WeeklyTrend
+from utils.utils import get_local_now, get_previous_week_range
 
 
 @pytest.mark.django_db
 class TestUserWeeklyTrendAdmin:
     """UserWeeklyTrendAdmin 테스트"""
 
-    def test_get_queryset(
-        self,
-        user_weekly_trend_admin,
-        user_weekly_trend: UserWeeklyTrend,
-        request_factory,
+    def test_list_display_configuration(self, user_weekly_trend_admin):
+        """list_display 설정 테스트"""
+        expected_list_display = (
+            "id",
+            "user_info",
+            "week_range",
+            "summarize_insight",
+            "is_processed_colored",
+            "processed_at_formatted",
+            "created_at",
+        )
+        assert user_weekly_trend_admin.list_display == expected_list_display
+
+    def test_list_filter_configuration(self, user_weekly_trend_admin):
+        """list_filter 설정 테스트"""
+        expected_list_filter = ("is_processed", "week_start_date")
+        assert user_weekly_trend_admin.list_filter == expected_list_filter
+
+    def test_search_fields_configuration(self, user_weekly_trend_admin):
+        """search_fields 설정 테스트"""
+        expected_search_fields = ("user__username", "insight")
+        assert user_weekly_trend_admin.search_fields == expected_search_fields
+
+    def test_readonly_fields_configuration(self, user_weekly_trend_admin):
+        """readonly_fields 설정 테스트"""
+        expected_readonly_fields = (
+            "processed_at",
+            "render_full_preview",
+            "formatted_insight_json",
+        )
+        assert (
+            user_weekly_trend_admin.readonly_fields == expected_readonly_fields
+        )
+
+    def test_raw_id_fields_configuration(self, user_weekly_trend_admin):
+        """raw_id_fields 설정 테스트"""
+        expected_raw_id_fields = ("user",)
+        assert user_weekly_trend_admin.raw_id_fields == expected_raw_id_fields
+
+    def test_fieldsets_configuration(self, user_weekly_trend_admin):
+        """fieldsets 설정 테스트"""
+        fieldsets = user_weekly_trend_admin.fieldsets
+        assert len(fieldsets) == 4
+
+    def test_actions_configuration(self, user_weekly_trend_admin):
+        """actions 설정 테스트"""
+        expected_actions = ["mark_as_processed"]
+        assert user_weekly_trend_admin.actions == expected_actions
+
+    def test_get_queryset_select_related(self, user_weekly_trend_admin):
+        """get_queryset 메소드가 select_related('user')를 포함하는지 테스트"""
+        request = HttpRequest()
+        request.method = "GET"
+        queryset = user_weekly_trend_admin.get_queryset(request)
+        assert hasattr(queryset, "query")
+        assert "user" in str(queryset.query.select_related)
+
+    def test_user_info_with_user(
+        self, user_weekly_trend_admin, user_weekly_trend
     ):
-        """get_queryset 메소드 테스트"""
-        qs = user_weekly_trend_admin.get_queryset(request_factory)
-        assert user_weekly_trend in qs
-        # select_related 검증은 어려우므로 메소드가 에러 없이 실행되는지만 확인
-
-    def test_user_info(self, user_weekly_trend_admin, user_weekly_trend):
-        """user_info 메소드 테스트"""
-        with patch("django.urls.reverse") as mock_reverse:
-            mock_reverse.return_value = (
-                f"/admin/users/user/{user_weekly_trend.user.id}/change/"
-            )
-            result = user_weekly_trend_admin.user_info(user_weekly_trend)
-
+        """user_info 메소드 테스트 (사용자 있음)"""
+        result = user_weekly_trend_admin.user_info(user_weekly_trend)
         assert user_weekly_trend.user.username in result
+        assert "href=" in result
+        assert 'target="_blank"' in result
 
-    def test_week_range(
-        self, user_weekly_trend_admin, user_weekly_trend: UserWeeklyTrend
+    def test_user_info_without_user(self, user_weekly_trend_admin):
+        """user_info 메소드 테스트 (사용자 없음)"""
+        # DB에 저장하지 않고 메모리상 객체만 생성, 현재는 Not Null 제약 조건 있음
+        mock_obj = MagicMock()
+        mock_obj.user = None
+
+        result = user_weekly_trend_admin.user_info(mock_obj)
+        assert result == "-"
+
+    def test_user_info_with_user_no_username(
+        self, user_weekly_trend_admin, user_weekly_trend
     ):
-        """week_range 메소드 테스트"""
+        """user_info 메소드 테스트 (사용자명 없음)"""
+        user_weekly_trend.user.username = None
+        user_weekly_trend.user.save()
+        result = user_weekly_trend_admin.user_info(user_weekly_trend)
+        assert f"사용자 {user_weekly_trend.user.id}" in result
+        assert "href=" in result
+
+    def test_summarize_insight_with_valid_data(
+        self, user_weekly_trend_admin, user_weekly_trend
+    ):
+        """summarize_insight 메소드 테스트 (유효한 데이터)"""
+        result = user_weekly_trend_admin.summarize_insight(user_weekly_trend)
+        if user_weekly_trend.insight.get("user_weekly_stats"):
+            assert "조회수:" in result
+            assert "새글:" in result
+        if user_weekly_trend.insight.get("trending_summary"):
+            assert "신규글:" in result
+
+    def test_summarize_insight_with_stats_only(
+        self, user_weekly_trend_admin, user_weekly_trend
+    ):
+        """summarize_insight 메소드 테스트 (통계만 있는 경우)"""
+        user_weekly_trend.insight = {
+            "user_weekly_stats": {"views": 250, "new_posts": 3}
+        }
+        user_weekly_trend.save()
+        result = user_weekly_trend_admin.summarize_insight(user_weekly_trend)
+        assert "조회수: 250" in result
+        assert "새글: 3" in result
+        assert "신규글:" not in result
+
+    def test_summarize_insight_no_data(self, user_weekly_trend_admin):
+        """summarize_insight 메소드 테스트 (데이터 없음)"""
+        week_start, week_end = get_previous_week_range()
+        user_weekly_trend = UserWeeklyTrend(
+            week_start_date=week_start, week_end_date=week_end, insight=None
+        )
+        result = user_weekly_trend_admin.summarize_insight(user_weekly_trend)
+        assert result == "데이터 없음"
+
+    def test_summarize_insight_invalid_data_type(
+        self, user_weekly_trend_admin
+    ):
+        """summarize_insight 메소드 테스트 (잘못된 데이터 타입)"""
+        week_start, week_end = get_previous_week_range()
+        user_weekly_trend = UserWeeklyTrend(
+            week_start_date=week_start,
+            week_end_date=week_end,
+            insight="invalid_string_data",
+        )
+        result = user_weekly_trend_admin.summarize_insight(user_weekly_trend)
+        assert result == "데이터 없음"
+
+    def test_summarize_insight_empty_dict(self, user_weekly_trend_admin):
+        """summarize_insight 메소드 테스트 (빈 딕셔너리)"""
+        week_start, week_end = get_previous_week_range()
+        user_weekly_trend = UserWeeklyTrend(
+            week_start_date=week_start, week_end_date=week_end, insight={}
+        )
+        result = user_weekly_trend_admin.summarize_insight(user_weekly_trend)
+        assert result == "요약 정보 없음"
+
+    def test_summarize_insight_with_trending_summary_empty_title(
+        self, user_weekly_trend_admin, user_weekly_trend
+    ):
+        """summarize_insight 메소드 테스트 (trending_summary는 있지만 title이 빈 경우)"""
+        user_weekly_trend.insight = {
+            "user_weekly_stats": {"views": 100, "new_posts": 2},
+            "trending_summary": [{"title": "", "summary": "내용만 있음"}],
+        }
+        user_weekly_trend.save()
+
+        result = user_weekly_trend_admin.summarize_insight(user_weekly_trend)
+        assert "조회수: 100" in result
+        assert "새글: 2" in result
+        assert "신규글:" not in result
+
+    def test_summarize_insight_with_trending_summary_not_list(
+        self, user_weekly_trend_admin, user_weekly_trend
+    ):
+        """summarize_insight 메소드 테스트 (trending_summary가 리스트가 아닌 경우)"""
+        user_weekly_trend.insight = {
+            "user_weekly_stats": {"views": 100, "new_posts": 2},
+            "trending_summary": "not a list",
+        }
+        user_weekly_trend.save()
+
+        result = user_weekly_trend_admin.summarize_insight(user_weekly_trend)
+        assert "조회수: 100" in result
+        assert "새글: 2" in result
+        assert "신규글:" not in result
+
+    def test_render_full_preview_with_weekly_trend(
+        self, user_weekly_trend_admin, user_weekly_trend, weekly_trend
+    ):
+        """render_full_preview 메소드 테스트 (WeeklyTrend 존재)"""
+        weekly_trend.week_start_date = user_weekly_trend.week_start_date
+        weekly_trend.week_end_date = user_weekly_trend.week_end_date
+        weekly_trend.insight = {"trending_summary": [{"title": "주간 트렌드"}]}
+        weekly_trend.save()
+
+        with patch("django.template.loader.render_to_string") as mock_render:
+            mock_render.return_value = "<div>Mocked HTML</div>"
+            with patch("utils.utils.from_dict") as mock_from_dict:
+                mock_insight = MagicMock()
+                mock_insight.to_dict.return_value = {"mocked": "data"}
+                mock_from_dict.return_value = mock_insight
+
+                result = user_weekly_trend_admin.render_full_preview(
+                    user_weekly_trend
+                )
+                assert "<iframe" in result
+                assert "style=" in result
+                assert "field-render_full_preview" in result
+                assert "max-width: 1400px" in result
+
+    def test_render_full_preview_without_weekly_trend(
+        self, user_weekly_trend_admin, user_weekly_trend
+    ):
+        """render_full_preview 메소드 테스트 (WeeklyTrend 없음)"""
+        WeeklyTrend.objects.filter(
+            week_start_date=user_weekly_trend.week_start_date,
+            week_end_date=user_weekly_trend.week_end_date,
+        ).delete()
+
+        with patch("django.template.loader.render_to_string") as mock_render:
+            mock_render.side_effect = [
+                "<div>User Weekly Trend HTML</div>",
+                "<div>Final HTML with warning</div>",
+            ]
+            with patch("utils.utils.from_dict") as mock_from_dict:
+                mock_insight = MagicMock()
+                mock_insight.to_dict.return_value = {"mocked": "data"}
+                mock_from_dict.return_value = mock_insight
+
+                result = user_weekly_trend_admin.render_full_preview(
+                    user_weekly_trend
+                )
+                assert "<iframe" in result
+
+    def test_render_full_preview_weekly_trend_without_insight(
+        self, user_weekly_trend_admin, user_weekly_trend, weekly_trend
+    ):
+        """render_full_preview 메소드 테스트 (WeeklyTrend는 있지만 insight 없음)"""
+        weekly_trend.week_start_date = user_weekly_trend.week_start_date
+        weekly_trend.week_end_date = user_weekly_trend.week_end_date
+        weekly_trend.insight = {}  # null 대신 빈 딕셔너리
+        weekly_trend.save()
+
+        with patch("django.template.loader.render_to_string") as mock_render:
+            mock_render.side_effect = [
+                "<div>User Weekly Trend HTML</div>",
+                "<div>Final HTML</div>",
+            ]
+            with patch("utils.utils.from_dict") as mock_from_dict:
+                mock_insight = MagicMock()
+                mock_insight.to_dict.return_value = {"mocked": "data"}
+                mock_from_dict.return_value = mock_insight
+
+                result = user_weekly_trend_admin.render_full_preview(
+                    user_weekly_trend
+                )
+                assert "<iframe" in result
+
+    def test_render_full_preview_no_insight(self, user_weekly_trend_admin):
+        """render_full_preview 메소드 테스트 (인사이트 없음)"""
+        week_start, week_end = get_previous_week_range()
+        user_weekly_trend = UserWeeklyTrend(
+            week_start_date=week_start, week_end_date=week_end, insight=None
+        )
+        result = user_weekly_trend_admin.render_full_preview(user_weekly_trend)
+        assert result == "No insight data to preview."
+
+    def test_render_full_preview_exception_handling(
+        self, user_weekly_trend_admin, user_weekly_trend
+    ):
+        """render_full_preview 메소드 테스트 (예외 발생)"""
+        with patch(
+            "utils.utils.from_dict", side_effect=Exception("Test error")
+        ):
+            result = user_weekly_trend_admin.render_full_preview(
+                user_weekly_trend
+            )
+            assert "Error rendering preview: Test error" in result
+
+    def test_formatted_insight_json_with_data(
+        self, user_weekly_trend_admin, user_weekly_trend
+    ):
+        """formatted_insight_json 메소드 테스트 (데이터 있음)"""
+        result = user_weekly_trend_admin.formatted_insight_json(
+            user_weekly_trend
+        )
+        assert "<pre><code>" in result
+        assert "</code></pre>" in result
+
+    def test_formatted_insight_json_no_data(self, user_weekly_trend_admin):
+        """formatted_insight_json 메소드 테스트 (데이터 없음)"""
+        week_start, week_end = get_previous_week_range()
+        user_weekly_trend = UserWeeklyTrend(
+            week_start_date=week_start, week_end_date=week_end, insight=None
+        )
+        result = user_weekly_trend_admin.formatted_insight_json(
+            user_weekly_trend
+        )
+        assert result == "No data"
+
+    def test_mark_as_processed(
+        self, user_weekly_trend_admin, user_weekly_trend
+    ):
+        """mark_as_processed 메소드 테스트"""
+        user_weekly_trend.is_processed = False
+        user_weekly_trend.processed_at = None
+        user_weekly_trend.save()
+
+        request = HttpRequest()
+        request.method = "POST"
+        request.user = MagicMock()
+
+        with patch("utils.utils.get_local_now") as mock_now:
+            mock_now.return_value = get_local_now()
+            with patch.object(
+                user_weekly_trend_admin, "message_user"
+            ) as mock_message:
+                user_weekly_trend_admin.mark_as_processed(
+                    request,
+                    UserWeeklyTrend.objects.filter(pk=user_weekly_trend.pk),
+                )
+                mock_message.assert_called_once()
+                message_text = mock_message.call_args[0][1]
+                assert "사용자 인사이트" in message_text
+                assert "처리 완료로 표시되었습니다" in message_text
+
+        user_weekly_trend.refresh_from_db()
+        assert user_weekly_trend.is_processed is True
+        assert user_weekly_trend.processed_at is not None
+
+    def test_mark_as_processed_multiple_items(
+        self, user_weekly_trend_admin, user_weekly_trend, user
+    ):
+        """mark_as_processed 메소드 테스트 (여러 항목)"""
+        # 다른 주차로 생성하여 unique constraint 회피
+        other_week_start, other_week_end = get_previous_week_range()
+        other_week_start = other_week_start.replace(
+            day=other_week_start.day + 7
+        )
+        other_week_end = other_week_end.replace(day=other_week_end.day + 7)
+
+        user_weekly_trend_2 = UserWeeklyTrend.objects.create(
+            user=user,
+            week_start_date=other_week_start,
+            week_end_date=other_week_end,
+            insight={"test": "data2"},
+            is_processed=False,
+        )
+
+        request = HttpRequest()
+        request.method = "POST"
+        request.user = MagicMock()
+
+        with patch("utils.utils.get_local_now") as mock_now:
+            mock_now.return_value = get_local_now()
+            with patch.object(
+                user_weekly_trend_admin, "message_user"
+            ) as mock_message:
+                queryset = UserWeeklyTrend.objects.filter(
+                    pk__in=[user_weekly_trend.pk, user_weekly_trend_2.pk]
+                )
+                user_weekly_trend_admin.mark_as_processed(request, queryset)
+                message_text = mock_message.call_args[0][1]
+                assert "2개의 사용자 인사이트" in message_text
+
+    def test_week_range(self, user_weekly_trend_admin, user_weekly_trend):
+        """week_range 메소드 테스트 (BaseTrendAdminMixin에서 상속)"""
         result = user_weekly_trend_admin.week_range(user_weekly_trend)
         expected_format = f"{user_weekly_trend.week_start_date.strftime('%Y-%m-%d')} ~ {user_weekly_trend.week_end_date.strftime('%Y-%m-%d')}"
         assert expected_format in result
 
     def test_is_processed_colored_true(
-        self, user_weekly_trend_admin, user_weekly_trend: UserWeeklyTrend
+        self, user_weekly_trend_admin, user_weekly_trend
     ):
         """is_processed_colored 메소드 테스트 (처리 완료)"""
         user_weekly_trend.is_processed = True
         user_weekly_trend.save()
-
         result = user_weekly_trend_admin.is_processed_colored(
             user_weekly_trend
         )
@@ -53,12 +380,11 @@ class TestUserWeeklyTrendAdmin:
         assert "✓" in result
 
     def test_is_processed_colored_false(
-        self, user_weekly_trend_admin, user_weekly_trend: UserWeeklyTrend
+        self, user_weekly_trend_admin, user_weekly_trend
     ):
         """is_processed_colored 메소드 테스트 (미처리)"""
         user_weekly_trend.is_processed = False
         user_weekly_trend.save()
-
         result = user_weekly_trend_admin.is_processed_colored(
             user_weekly_trend
         )
@@ -66,50 +392,24 @@ class TestUserWeeklyTrendAdmin:
         assert "✗" in result
 
     def test_processed_at_formatted_with_date(
-        self, user_weekly_trend_admin, user_weekly_trend: UserWeeklyTrend
+        self, user_weekly_trend_admin, user_weekly_trend
     ):
         """processed_at_formatted 메소드 테스트 (날짜 있음)"""
         now = get_local_now()
         user_weekly_trend.processed_at = now
         user_weekly_trend.save()
-
         result = user_weekly_trend_admin.processed_at_formatted(
             user_weekly_trend
         )
         assert now.strftime("%Y-%m-%d %H:%M") == result
 
     def test_processed_at_formatted_no_date(
-        self, user_weekly_trend_admin, user_weekly_trend: UserWeeklyTrend
+        self, user_weekly_trend_admin, user_weekly_trend
     ):
         """processed_at_formatted 메소드 테스트 (날짜 없음)"""
         user_weekly_trend.processed_at = None
         user_weekly_trend.save()
-
         result = user_weekly_trend_admin.processed_at_formatted(
             user_weekly_trend
         )
         assert result == "-"
-
-    def test_mark_as_processed(
-        self,
-        user_weekly_trend_admin,
-        user_weekly_trend: UserWeeklyTrend,
-        request_factory,
-    ):
-        """mark_as_processed 메소드 테스트"""
-        user_weekly_trend.is_processed = False
-        user_weekly_trend.processed_at = None
-        user_weekly_trend.save()
-
-        with patch("utils.utils.get_local_now") as mock_now:
-            mock_now.return_value = get_local_now()
-            user_weekly_trend_admin.mark_as_processed(
-                request_factory,
-                user_weekly_trend.__class__.objects.filter(
-                    pk=user_weekly_trend.pk
-                ),
-            )
-
-        user_weekly_trend.refresh_from_db()
-        assert user_weekly_trend.is_processed is True
-        assert user_weekly_trend.processed_at is not None

--- a/insight/tests/test_weekly_trend_admin.py
+++ b/insight/tests/test_weekly_trend_admin.py
@@ -1,6 +1,8 @@
+# poetry run pytest insight/tests/test_weekly_trend_admin.py -v
 from unittest.mock import patch
 
 import pytest
+from django.utils.safestring import SafeString
 
 from insight.models import WeeklyTrend
 from utils.utils import get_local_now
@@ -59,21 +61,230 @@ class TestWeeklyTrendAdmin:
         result = weekly_trend_admin.processed_at_formatted(weekly_trend)
         assert result == "-"
 
-    def test_mark_as_processed(
-        self, weekly_trend_admin, weekly_trend: WeeklyTrend, request_factory
+    def test_summarize_insight_with_data(
+        self, weekly_trend_admin, weekly_trend: WeeklyTrend
     ):
-        """mark_as_processed 메소드 테스트"""
+        """summarize_insight 메소드 테스트 (데이터 있음)"""
+        result = weekly_trend_admin.summarize_insight(weekly_trend)
+
+        # trending_summary 개수 확인
+        summary_count = len(weekly_trend.insight.get("trending_summary", []))
+        assert f"요약: {summary_count}개" in result
+
+        # 키워드 확인
+        keywords = weekly_trend.insight.get("trend_analysis", {}).get(
+            "hot_keywords", []
+        )
+        if keywords:
+            assert "키워드:" in result
+            assert keywords[0] in result
+
+    def test_summarize_insight_no_data(
+        self, weekly_trend_admin, empty_insight_weekly_trend: WeeklyTrend
+    ):
+        """summarize_insight 메소드 테스트 (데이터 없음)"""
+        result = weekly_trend_admin.summarize_insight(
+            empty_insight_weekly_trend
+        )
+        assert "요약: 0개" in result
+
+    def test_summarize_insight_non_dict(
+        self, weekly_trend_admin, weekly_trend: WeeklyTrend
+    ):
+        """summarize_insight 메소드 테스트 (비딕셔너리 데이터)"""
+        weekly_trend.insight = "invalid_data"
+        weekly_trend.save()
+
+        result = weekly_trend_admin.summarize_insight(weekly_trend)
+        assert result == "데이터 없음"
+
+    @patch("insight.admin.weekly_trend_admin.render_to_string")
+    def test_render_full_preview_success(
+        self,
+        mock_render_to_string,
+        weekly_trend_admin,
+        weekly_trend: WeeklyTrend,
+    ):
+        """render_full_preview 메소드 테스트 (성공)"""
+        # render_to_string의 반환값 설정
+        mock_render_to_string.side_effect = [
+            "<div>Weekly Trend HTML</div>",
+            "<html><body>Final HTML</body></html>",
+        ]
+
+        result = weekly_trend_admin.render_full_preview(weekly_trend)
+
+        # SafeString 타입인지 확인
+        assert isinstance(result, SafeString)
+
+        # iframe이 포함되어 있는지 확인
+        assert "<iframe" in str(result)
+        assert "srcdoc=" in str(result)
+
+        # CSS 스타일이 포함되어 있는지 확인
+        assert "<style>" in str(result)
+        assert ".field-render_full_preview" in str(result)
+
+        # render_to_string이 올바른 횟수로 호출되었는지 확인
+        assert mock_render_to_string.call_count == 2
+
+    def test_render_full_preview_no_insight(
+        self, weekly_trend_admin, empty_insight_weekly_trend: WeeklyTrend
+    ):
+        """render_full_preview 메소드 테스트 (인사이트 없음)"""
+        result = weekly_trend_admin.render_full_preview(
+            empty_insight_weekly_trend
+        )
+        assert result == "No insight data to preview."
+
+    @patch("insight.admin.weekly_trend_admin.render_to_string")
+    def test_render_full_preview_exception(
+        self,
+        mock_render_to_string,
+        weekly_trend_admin,
+        weekly_trend: WeeklyTrend,
+    ):
+        """render_full_preview 메소드 테스트 (예외 발생)"""
+        # render_to_string에서 예외 발생하도록 설정
+        mock_render_to_string.side_effect = Exception("Template error")
+
+        result = weekly_trend_admin.render_full_preview(weekly_trend)
+        assert "Error rendering preview: Template error" in result
+
+    def test_formatted_insight_json_with_data(
+        self, weekly_trend_admin, weekly_trend: WeeklyTrend
+    ):
+        """formatted_insight_json 메소드 테스트 (데이터 있음)"""
+        result = weekly_trend_admin.formatted_insight_json(weekly_trend)
+
+        # SafeString 타입인지 확인
+        assert isinstance(result, SafeString)
+
+        # HTML 구조 확인
+        assert "<pre><code>" in str(result)
+        assert "</code></pre>" in str(result)
+
+        # JSON 데이터가 포함되어 있는지 확인
+        assert "trending_summary" in str(result)
+
+    def test_formatted_insight_json_no_data(
+        self, weekly_trend_admin, empty_insight_weekly_trend: WeeklyTrend
+    ):
+        """formatted_insight_json 메소드 테스트 (데이터 없음)"""
+        result = weekly_trend_admin.formatted_insight_json(
+            empty_insight_weekly_trend
+        )
+        assert result == "No data"
+
+    def test_mark_as_processed(
+        self,
+        weekly_trend_admin,
+        weekly_trend: WeeklyTrend,
+        request_factory,
+    ):
+        """mark_as_processed 액션 테스트"""
+        # 초기 상태 설정
         weekly_trend.is_processed = False
         weekly_trend.processed_at = None
         weekly_trend.save()
 
-        with patch("utils.utils.get_local_now") as mock_now:
-            mock_now.return_value = get_local_now()
-            weekly_trend_admin.mark_as_processed(
-                request_factory,
-                weekly_trend.__class__.objects.filter(pk=weekly_trend.pk),
-            )
+        # QuerySet 생성
+        queryset = WeeklyTrend.objects.filter(pk=weekly_trend.pk)
 
+        # mark_as_processed 실행
+        weekly_trend_admin.mark_as_processed(request_factory, queryset)
+
+        # 결과 확인
         weekly_trend.refresh_from_db()
         assert weekly_trend.is_processed is True
         assert weekly_trend.processed_at is not None
+
+        # message_user가 호출되었는지 확인 (실제로는 _messages.add가 호출됨)
+        request_factory._messages.add.assert_called_once()
+
+    def test_mark_as_processed_multiple_objects(
+        self,
+        weekly_trend_admin,
+        request_factory,
+        db,
+        sample_weekly_trend_insight,
+    ):
+        """mark_as_processed 액션 테스트 (여러 객체)"""
+        from datetime import date
+
+        # 다른 주간 범위로 WeeklyTrend 객체 생성 (unique 제약조건 피하기)
+        week_start1 = date(2025, 8, 1)  # 다른 주차
+        week_end1 = date(2025, 8, 7)
+        week_start2 = date(2025, 8, 8)  # 또 다른 주차
+        week_end2 = date(2025, 8, 14)
+
+        trend1 = WeeklyTrend.objects.create(
+            week_start_date=week_start1,
+            week_end_date=week_end1,
+            insight=sample_weekly_trend_insight.to_json_dict(),
+            is_processed=False,
+        )
+        trend2 = WeeklyTrend.objects.create(
+            week_start_date=week_start2,
+            week_end_date=week_end2,
+            insight=sample_weekly_trend_insight.to_json_dict(),
+            is_processed=False,
+        )
+
+        # QuerySet 생성
+        queryset = WeeklyTrend.objects.filter(pk__in=[trend1.pk, trend2.pk])
+
+        # mark_as_processed 실행
+        weekly_trend_admin.mark_as_processed(request_factory, queryset)
+
+        # 결과 확인
+        trend1.refresh_from_db()
+        trend2.refresh_from_db()
+
+        assert trend1.is_processed is True
+        assert trend1.processed_at is not None
+        assert trend2.is_processed is True
+        assert trend2.processed_at is not None
+
+        # message_user가 호출되었는지 확인 (실제로는 _messages.add가 호출됨)
+        request_factory._messages.add.assert_called_once()
+
+    def test_admin_configuration(self, weekly_trend_admin):
+        """Admin 클래스 설정 테스트"""
+        # list_display 확인
+        expected_list_display = (
+            "id",
+            "week_range",
+            "summarize_insight",
+            "is_processed_colored",
+            "processed_at_formatted",
+            "created_at",
+        )
+        assert weekly_trend_admin.list_display == expected_list_display
+
+        # list_filter 확인
+        expected_list_filter = ("is_processed", "week_start_date")
+        assert weekly_trend_admin.list_filter == expected_list_filter
+
+        # search_fields 확인
+        expected_search_fields = ("insight",)
+        assert weekly_trend_admin.search_fields == expected_search_fields
+
+        # readonly_fields 확인
+        expected_readonly_fields = (
+            "processed_at",
+            "render_full_preview",
+            "formatted_insight_json",
+        )
+        assert weekly_trend_admin.readonly_fields == expected_readonly_fields
+
+        # actions 확인
+        expected_actions = ["mark_as_processed"]
+        assert weekly_trend_admin.actions == expected_actions
+
+        # fieldsets 확인
+        assert len(weekly_trend_admin.fieldsets) == 4
+        assert weekly_trend_admin.fieldsets[0][0] == "기간 정보"
+        assert weekly_trend_admin.fieldsets[1][0] == "뉴스레터 미리보기"
+        assert weekly_trend_admin.fieldsets[2][0] == "원본 데이터 (JSON)"
+        assert weekly_trend_admin.fieldsets[3][0] == "처리 상태"


### PR DESCRIPTION
## 🔥 변경 사항
- 주간 매일 템플릿 활용해서, admin 에서 미리 보기 강화!
- 그에 따른 admin test code 전체적으로 리뉴얼
- 주간 배치 cron 설정!

## 📸 스크린샷 (UI 변경 시 필수)
<img width="1908" height="1730" alt="image" src="https://github.com/user-attachments/assets/572cd867-c981-4c5f-9fe3-f26be7610764" />
<img width="1812" height="1170" alt="image" src="https://github.com/user-attachments/assets/bc3c34e7-a61c-46ce-875f-ea19d8af5614" />


## 📌 체크리스트
- [X] 기능이 정상적으로 동작하는지 테스트 완료
- [X] 코드 스타일 가이드 준수 여부 확인
- [X] 관련 문서 업데이트 완료 (필요 시)
