### PR TITLE
[26.03.08 / TASK-280] Hotfix - 컨슈머와 장고 로그 권한 이슈, 아예 디렉토리 분리로 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ serena
 CLAUDE.md
 AGENTS.md
 SYSTEM_DESIGN.md
-plan.md
+*plan.md
 
 # CUSTOM
 **/timescale_data*/**
@@ -28,6 +28,7 @@ db.sqlite3
 db.sqlite3-journal
 media
 logs/**
+consumer-logs/**
 
 # If your build process includes running collectstatic, then you probably don't need or want to include staticfiles/
 # in your Git repository. Update and uncomment the following line accordingly.

--- a/Dockerfile.consumer
+++ b/Dockerfile.consumer
@@ -46,8 +46,8 @@ COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 # Copy application code
 COPY . .
 
-# Create logs directory
-RUN mkdir -p /app/logs
+# Create consumer logs directory (Django의 logs/와 분리)
+RUN mkdir -p /app/consumer-logs
 
 # Run consumer (poetry 없이 직접 python 실행)
 CMD ["python", "-m", "consumer.stats_refresh_consumer"]

--- a/backoffice/settings/consumer.py
+++ b/backoffice/settings/consumer.py
@@ -5,6 +5,8 @@ Docker container에서 consumer 실행 시 사용.
 - DB 연결은 환경변수로 설정 (local/prod 모두 지원)
 """
 
+import os
+
 from .base import *  # noqa: F401, F403
 
 DEBUG = False
@@ -25,9 +27,13 @@ MIDDLEWARE = [  # noqa: F405
 
 INTERNAL_IPS = []
 
-# Consumer 전용 파일 핸들러 — 모든 로그를 consumer.log에 기록
-# scraping.log 등 Django 로그 파일은 권한 충돌 방지를 위해 제거하고,
-# 해당 로거들의 파일 출력을 consumer_file로 통합
+# Consumer 전용 로그 디렉토리 — Django의 logs/와 완전 분리하여 권한 충돌 방지
+CONSUMER_LOG_DIR = os.path.join(BASE_DIR, "consumer-logs")  # noqa: F405
+os.makedirs(CONSUMER_LOG_DIR, exist_ok=True)
+
+# Consumer 전용 파일 핸들러 — 모든 로그를 consumer-logs/consumer.log에 기록
+# Django 프로세스(ubuntu)와 Consumer(Docker root)의 로그 디렉토리를 분리하여
+# 바인드 마운트 권한 충돌을 원천 차단
 LOGGING["handlers"]["consumer_file"] = {  # noqa: F405
     "level": "INFO",
     "class": "backoffice.logging_handlers.GzipTimedRotatingFileHandler",
@@ -37,12 +43,14 @@ LOGGING["handlers"]["consumer_file"] = {  # noqa: F405
     "backupCount": 7,
     "formatter": "default_formatter",
     "encoding": "utf-8",
-    "filename": os.path.join(BASE_DIR, "logs", "consumer.log"),  # noqa: F405
+    "filename": os.path.join(CONSUMER_LOG_DIR, "consumer.log"),
 }
 
+# base.py의 Django 전용 파일 핸들러 제거
 for handler_name in ("scraping_file", "newsletter_file", "django_file"):
     LOGGING["handlers"].pop(handler_name, None)  # noqa: F405
 
+# 모든 로거를 consumer_console + consumer_file로 통합
 for logger_name in ("scraping", "newsletter", "django", "consumer"):
     logger_conf = LOGGING["loggers"].setdefault(  # noqa: F405
         logger_name,

--- a/backoffice/tests/test_settings.py
+++ b/backoffice/tests/test_settings.py
@@ -74,7 +74,7 @@ def consumer_logging():
         "backupCount": 7,
         "formatter": "default_formatter",
         "encoding": "utf-8",
-        "filename": "logs/consumer.log",
+        "filename": "consumer-logs/consumer.log",
     }
 
     for handler_name in ("scraping_file", "newsletter_file", "django_file"):
@@ -121,3 +121,11 @@ class TestConsumerLoggingOverride:
         assert handler["backupCount"] == 7
         assert handler["when"] == "midnight"
         assert handler["utc"] is True
+
+    def test_consumer_log_dir_is_separate_from_django(self, consumer_logging):
+        """Consumer 로그 경로가 Django의 logs/와 분리되어야 한다."""
+        consumer_path = consumer_logging["handlers"]["consumer_file"][
+            "filename"
+        ]
+        assert "consumer-logs/" in consumer_path
+        assert not consumer_path.startswith("logs/")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,5 +19,5 @@ services:
       DJANGO_SETTINGS_MODULE: backoffice.settings.consumer
     restart: unless-stopped
     volumes:
-      - ./logs:/app/logs
+      - ./consumer-logs:/app/consumer-logs
     command: python -m consumer.stats_refresh_consumer


### PR DESCRIPTION
## 🔥 변경 사항
#49 에 이어 여전히 이슈 발생
- 그에 따라 logs 디렉토리를 아예 분리해버림. 절대 발생못하게. 

## 🏷 관련 이슈
- 관련 이슈: `#49`

## 📌 체크리스트
- [X] 기능이 정상적으로 동작하는지 테스트 완료
- [X] 코드 스타일 가이드 준수 여부 확인
- [X] 관련 문서 업데이트 완료 (필요 시)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 컨슈머 로그를 별도 디렉토리로 분리했습니다. 로그 파일들이 더욱 명확하게 구성되어 로그 관리와 모니터링이 개선되었습니다.

* **테스트**
  * 로그 디렉토리 분리 검증 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->