### PR TITLE
[26.05.17 / TASK-288] Feature - old data clean up, 6개월 초과 데이터 정리 & 자동 정리 배치 추가

### DIFF
--- a/.github/workflows/run-daily-stats-cleanup.yaml
+++ b/.github/workflows/run-daily-stats-cleanup.yaml
@@ -1,4 +1,4 @@
-name: Monthly Stats Cleanup
+name: Daily Stats Cleanup
 
 on:
   workflow_dispatch:
@@ -11,16 +11,12 @@ on:
         description: 'dry-run 여부 (true/false)'
         required: false
         default: 'true'
-      force:
-        description: 'KST 1~2일 day-guard 우회 (true/false)'
-        required: false
-        default: 'true'
   schedule:
-    # UTC 1일 19:00 = KST 2일 04:00 — day-guard 가 KST day in (1, 2) 양일 허용.
-    - cron: "0 19 1 * *"
+    # 매일 UTC 19:00 = KST 04:00 — 한국 사용자가 가장 적게 쓰는 시간대.
+    - cron: "0 19 * * *"
 
 jobs:
-  monthly-stats-cleanup:
+  daily-stats-cleanup:
     runs-on: ubuntu-latest
 
     steps:
@@ -73,16 +69,12 @@ jobs:
         env:
           DJANGO_SETTINGS_MODULE: backoffice.settings.prod
         run: |
-          # schedule 트리거 시 github.event.inputs 가 모두 null → fallback 적용:
-          #   retention_months='6', dry_run='false' (실제 삭제), force='false'
-          # day-guard 는 KST day in (1, 2) 양일 허용이라 cron(KST 2일) 정상 진입.
+          # schedule 트리거 시 inputs null → fallback: retention_months='6', dry_run='false' (실제 삭제).
+          # 초기 1회는 누적 데이터 폐기로 오래 걸릴 수 있음. 이후 매일 1일치만 정리되어 빠름.
           set -e
           ARGS="--retention-months ${{ github.event.inputs.retention_months || '6' }}"
           if [ "${{ github.event.inputs.dry_run || 'false' }}" = "true" ]; then
             ARGS="$ARGS --dry-run"
-          fi
-          if [ "${{ github.event.inputs.force || 'false' }}" = "true" ]; then
-            ARGS="$ARGS --force"
           fi
           poetry run python manage.py cleanup_old_stats $ARGS
 
@@ -96,7 +88,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "*Monthly Stats Cleanup*\n\n❌ *Status:* Failure\n📅 *Timestamp (KST):* ${{ env.KST_TIME }}\n🔗 *Workflow URL:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+              "text": "*Daily Stats Cleanup*\n\n❌ *Status:* Failure\n📅 *Timestamp (KST):* ${{ env.KST_TIME }}\n🔗 *Workflow URL:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/run-daily-stats-cleanup.yaml
+++ b/.github/workflows/run-daily-stats-cleanup.yaml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Create .env.prod file
         run: |
+          # run-daily-aggre-set*.yaml 와 동일한 secrets 구조 + Redis/Slack 보강
           echo "SECRET_KEY=${{ secrets.SECRET_KEY }}" >> .env.prod
           echo "DEBUG=False" >> .env.prod
           echo "DATABASE_ENGINE=${{ secrets.DATABASE_ENGINE }}" >> .env.prod
@@ -57,6 +58,16 @@ jobs:
           echo "POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}" >> .env.prod
           echo "POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}" >> .env.prod
           echo "POSTGRES_PORT=${{ secrets.POSTGRES_PORT }}" >> .env.prod
+          echo "AES_KEY_0=${{ secrets.AES_KEY_0 }}" >> .env.prod
+          echo "AES_KEY_1=${{ secrets.AES_KEY_1 }}" >> .env.prod
+          echo "AES_KEY_2=${{ secrets.AES_KEY_2 }}" >> .env.prod
+          echo "AES_KEY_3=${{ secrets.AES_KEY_3 }}" >> .env.prod
+          echo "AES_KEY_4=${{ secrets.AES_KEY_4 }}" >> .env.prod
+          echo "AES_KEY_5=${{ secrets.AES_KEY_5 }}" >> .env.prod
+          echo "AES_KEY_6=${{ secrets.AES_KEY_6 }}" >> .env.prod
+          echo "AES_KEY_7=${{ secrets.AES_KEY_7 }}" >> .env.prod
+          echo "AES_KEY_8=${{ secrets.AES_KEY_8 }}" >> .env.prod
+          echo "AES_KEY_9=${{ secrets.AES_KEY_9 }}" >> .env.prod
           echo "REDIS_HOST=${{ secrets.REDIS_HOST }}" >> .env.prod
           echo "REDIS_PORT=${{ secrets.REDIS_PORT }}" >> .env.prod
           echo "REDIS_PASSWORD_B64=${{ secrets.REDIS_PASSWORD_B64 }}" >> .env.prod

--- a/.github/workflows/run-monthly-stats-cleanup.yaml
+++ b/.github/workflows/run-monthly-stats-cleanup.yaml
@@ -73,6 +73,9 @@ jobs:
         env:
           DJANGO_SETTINGS_MODULE: backoffice.settings.prod
         run: |
+          # schedule 트리거 시 github.event.inputs 가 모두 null → fallback 적용:
+          #   retention_months='6', dry_run='false' (실제 삭제), force='false'
+          # day-guard 는 KST day in (1, 2) 양일 허용이라 cron(KST 2일) 정상 진입.
           set -e
           ARGS="--retention-months ${{ github.event.inputs.retention_months || '6' }}"
           if [ "${{ github.event.inputs.dry_run || 'false' }}" = "true" ]; then

--- a/.github/workflows/run-monthly-stats-cleanup.yaml
+++ b/.github/workflows/run-monthly-stats-cleanup.yaml
@@ -1,0 +1,99 @@
+name: Monthly Stats Cleanup
+
+on:
+  workflow_dispatch:
+    inputs:
+      retention_months:
+        description: '보존 개월 수'
+        required: false
+        default: '6'
+      dry_run:
+        description: 'dry-run 여부 (true/false)'
+        required: false
+        default: 'true'
+      force:
+        description: 'KST 1~2일 day-guard 우회 (true/false)'
+        required: false
+        default: 'true'
+  schedule:
+    # UTC 1일 19:00 = KST 2일 04:00 — day-guard 가 KST day in (1, 2) 양일 허용.
+    - cron: "0 19 1 * *"
+
+jobs:
+  monthly-stats-cleanup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13.0
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: 1.8.4
+
+      - name: Setup a local virtual environment
+        run: |
+          poetry config virtualenvs.create true --local
+          poetry config virtualenvs.in-project true --local
+
+      - name: Define a cache for the virtual environment
+        uses: actions/cache@v4
+        with:
+          path: ./.venv
+          key: venv-${{ hashFiles('poetry.lock') }}-${{ runner.os }}
+
+      - name: Install dependencies
+        run: poetry install --with dev
+
+      - name: Create .env.prod file
+        run: |
+          echo "SECRET_KEY=${{ secrets.SECRET_KEY }}" >> .env.prod
+          echo "DEBUG=False" >> .env.prod
+          echo "DATABASE_ENGINE=${{ secrets.DATABASE_ENGINE }}" >> .env.prod
+          echo "DATABASE_NAME=${{ secrets.DATABASE_NAME }}" >> .env.prod
+          echo "POSTGRES_USER=${{ secrets.POSTGRES_USER }}" >> .env.prod
+          echo "POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}" >> .env.prod
+          echo "POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}" >> .env.prod
+          echo "POSTGRES_PORT=${{ secrets.POSTGRES_PORT }}" >> .env.prod
+          echo "REDIS_HOST=${{ secrets.REDIS_HOST }}" >> .env.prod
+          echo "REDIS_PORT=${{ secrets.REDIS_PORT }}" >> .env.prod
+          echo "REDIS_PASSWORD_B64=${{ secrets.REDIS_PASSWORD_B64 }}" >> .env.prod
+          echo "REDIS_DB=${{ secrets.REDIS_DB }}" >> .env.prod
+          echo "SLACK_OPS_WEBHOOK=${{ secrets.SLACK_OPS_WEBHOOK }}" >> .env.prod
+
+      - name: Run cleanup_old_stats
+        id: cleanup
+        timeout-minutes: 30
+        env:
+          DJANGO_SETTINGS_MODULE: backoffice.settings.prod
+        run: |
+          set -e
+          ARGS="--retention-months ${{ github.event.inputs.retention_months || '6' }}"
+          if [ "${{ github.event.inputs.dry_run || 'false' }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          if [ "${{ github.event.inputs.force || 'false' }}" = "true" ]; then
+            ARGS="$ARGS --force"
+          fi
+          poetry run python manage.py cleanup_old_stats $ARGS
+
+      - name: Get Current KST Time
+        if: always()
+        run: echo "KST_TIME=$(TZ=Asia/Seoul date +'%Y-%m-%d %H:%M:%S')" >> $GITHUB_ENV
+
+      - name: Send Slack Notification on Failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: |
+            {
+              "text": "*Monthly Stats Cleanup*\n\n❌ *Status:* Failure\n📅 *Timestamp (KST):* ${{ env.KST_TIME }}\n🔗 *Workflow URL:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/README.md
+++ b/README.md
@@ -181,6 +181,17 @@ poetry run pre-commit run --all-files
 
 외부 producer(velog-dashboard 웹) 가 보낸 메시지는 필요한 신규 필드(`requestId`, `enqueuedAt`, `reclaimedCount`, `requestedBy`, `processingStartedAt`) 가 누락되어 있어도 consumer 의 `ensure_envelope` 가 자동 보강한다. 외부 변경 불필요.
 
+### Stats 데이터 정리 (cleanup_old_stats)
+
+`PostDailyStatistics` 의 6개월 이전 데이터를 TimescaleDB `drop_chunks` + ORM 폴백으로 정리. 매월 1일 KST 04:00 cron 자동 실행 (`.github/workflows/run-monthly-stats-cleanup.yaml`).
+
+```bash
+# 로컬 dry-run
+poetry run python manage.py cleanup_old_stats --dry-run --force
+# 운영 수동 실행 (workflow_dispatch)
+gh workflow run "Monthly Stats Cleanup" -f retention_months=6 -f dry_run=true -f force=true
+```
+
 ---
 
 ## Runserver

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ poetry run pre-commit run --all-files
 
 `PostDailyStatistics` 의 6개월 이전 데이터를 TimescaleDB `drop_chunks` + ORM 폴백으로 강제 폐기. 매일 KST 04:00 cron 자동 실행 (`.github/workflows/run-daily-stats-cleanup.yaml`). 초기 1회는 누적 데이터로 오래 걸리나 이후는 1일치만 정리되어 빠름.
 
-운영 DB 는 Supabase 기반 PostgreSQL + TimescaleDB extension. **Session Mode (포트 5432) 또는 Direct Connection 사용 필수** — Supabase Transaction Mode(6543)에서는 `SET LOCAL` / `transaction.atomic` 동작이 보장되지 않는다.
+운영 DB 는 Supabase 기반 PostgreSQL 15 + TimescaleDB extension. **Session Mode (포트 5432) 또는 Direct Connection 사용 필수** — Transaction Mode(6543)에서는 `SET LOCAL` / `transaction.atomic` 이 보장되지 않는다. 운영 DB role 은 `run-daily-aggre-set*.yaml` 의 `POSTGRES_USER` 와 동일 (이미 매일 stats INSERT/UPDATE 권한 보유 → `drop_chunks` 도 동일 권한).
 
 ```bash
 # 로컬 dry-run

--- a/README.md
+++ b/README.md
@@ -183,13 +183,15 @@ poetry run pre-commit run --all-files
 
 ### Stats 데이터 정리 (cleanup_old_stats)
 
-`PostDailyStatistics` 의 6개월 이전 데이터를 TimescaleDB `drop_chunks` + ORM 폴백으로 정리. 매월 1일 KST 04:00 cron 자동 실행 (`.github/workflows/run-monthly-stats-cleanup.yaml`).
+`PostDailyStatistics` 의 6개월 이전 데이터를 TimescaleDB `drop_chunks` + ORM 폴백으로 강제 폐기. 매일 KST 04:00 cron 자동 실행 (`.github/workflows/run-daily-stats-cleanup.yaml`). 초기 1회는 누적 데이터로 오래 걸리나 이후는 1일치만 정리되어 빠름.
+
+운영 DB 는 Supabase 기반 PostgreSQL + TimescaleDB extension. **Session Mode (포트 5432) 또는 Direct Connection 사용 필수** — Supabase Transaction Mode(6543)에서는 `SET LOCAL` / `transaction.atomic` 동작이 보장되지 않는다.
 
 ```bash
 # 로컬 dry-run
-poetry run python manage.py cleanup_old_stats --dry-run --force
+poetry run python manage.py cleanup_old_stats --dry-run
 # 운영 수동 실행 (workflow_dispatch)
-gh workflow run "Monthly Stats Cleanup" -f retention_months=6 -f dry_run=true -f force=true
+gh workflow run "Daily Stats Cleanup" -f retention_months=6 -f dry_run=true
 ```
 
 ---

--- a/posts/admin.py
+++ b/posts/admin.py
@@ -82,6 +82,8 @@ class PostAdmin(admin.ModelAdmin):
 
 @admin.register(PostDailyStatistics)
 class PostDailyStatisticsAdmin(admin.ModelAdmin):
+    """6개월 이전 데이터는 매월 1일 KST 04:00 cleanup_old_stats 배치가 자동 정리."""
+
     list_display = [
         "id",
         "post_title",

--- a/posts/management/commands/cleanup_old_stats.py
+++ b/posts/management/commands/cleanup_old_stats.py
@@ -2,6 +2,7 @@
 
 import logging
 import math
+import time
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -84,6 +85,7 @@ class Command(BaseCommand):
             )
             return
 
+        started_at = time.monotonic()
         try:
             dropped_chunks, cutoff_ts = self._drop_chunks_and_get_cutoff(
                 months
@@ -92,6 +94,14 @@ class Command(BaseCommand):
         except Exception as e:
             logger.exception("cleanup_old_stats failed")
             raise SystemExit(1) from e
+        elapsed = time.monotonic() - started_at
+        logger.info(
+            "cleanup_old_stats: cutoff=%s dropped_chunks=%d orm_deleted=%d elapsed=%.2fs",
+            cutoff_ts.isoformat(),
+            dropped_chunks,
+            orm_deleted,
+            elapsed,
+        )
         self.stdout.write(
             f"dropped {dropped_chunks} chunks, {orm_deleted} orm rows"
         )

--- a/posts/management/commands/cleanup_old_stats.py
+++ b/posts/management/commands/cleanup_old_stats.py
@@ -1,14 +1,10 @@
-"""PostDailyStatistics 의 6개월 이전 데이터를 drop_chunks 로 정리하는 배치."""
-
 import logging
 import math
 import time
 from datetime import datetime
-from zoneinfo import ZoneInfo
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connection, transaction
-from django.utils import timezone
 
 from modules.noti.slack_client import notify_ops
 from modules.redis.client import get_redis_client
@@ -19,7 +15,6 @@ logger = logging.getLogger(__name__)
 RETENTION_MONTHS_DEFAULT = 6
 ORM_CHUNK_DEFAULT = 5000
 COOLDOWN_KEY = "cleanup-old-stats"
-KST = ZoneInfo("Asia/Seoul")
 HYPERTABLE_NAME = "posts_postdailystatistics"
 
 
@@ -44,11 +39,6 @@ class Command(BaseCommand):
             action="store_true",
             help="삭제 없이 대상만 출력",
         )
-        parser.add_argument(
-            "--force",
-            action="store_true",
-            help="KST 1~2일 day-guard 우회 (수동 실행 전용)",
-        )
 
     def handle(self, *args, **options) -> None:
         months = options["retention_months"]
@@ -59,13 +49,6 @@ class Command(BaseCommand):
             )
         if chunk <= 0:
             raise CommandError(f"--chunk must be positive (got {chunk})")
-
-        if not options["force"] and timezone.now().astimezone(KST).day not in (
-            1,
-            2,
-        ):
-            self.stdout.write("not the 1st/2nd of month KST, skipping")
-            return
 
         if options["dry_run"]:
             with connection.cursor() as cursor:

--- a/posts/management/commands/cleanup_old_stats.py
+++ b/posts/management/commands/cleanup_old_stats.py
@@ -6,8 +6,8 @@ import time
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from django.core.management.base import BaseCommand
-from django.db import connection
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connection, transaction
 from django.utils import timezone
 
 from posts.models import PostDailyStatistics
@@ -52,11 +52,11 @@ class Command(BaseCommand):
         months = options["retention_months"]
         chunk = options["chunk"]
         if months <= 0:
-            raise SystemExit(
+            raise CommandError(
                 f"--retention-months must be positive (got {months})"
             )
         if chunk <= 0:
-            raise SystemExit(f"--chunk must be positive (got {chunk})")
+            raise CommandError(f"--chunk must be positive (got {chunk})")
 
         if not options["force"] and timezone.now().astimezone(KST).day not in (
             1,
@@ -93,7 +93,7 @@ class Command(BaseCommand):
             orm_deleted = self._orm_fallback(cutoff_ts, chunk)
         except Exception as e:
             logger.exception("cleanup_old_stats failed")
-            raise SystemExit(1) from e
+            raise CommandError(str(e)) from e
         elapsed = time.monotonic() - started_at
         logger.info(
             "cleanup_old_stats: cutoff=%s dropped_chunks=%d orm_deleted=%d elapsed=%.2fs",
@@ -107,8 +107,12 @@ class Command(BaseCommand):
         )
 
     def _drop_chunks_and_get_cutoff(self, months: int) -> tuple[int, datetime]:
-        """drop_chunks 호출 + cutoff_ts 산출. 동일 cursor 안에서 처리."""
-        with connection.cursor() as cursor:
+        """drop_chunks 호출 + cutoff_ts 산출.
+
+        Django 기본 autocommit 환경에서 `SET LOCAL` 이 효과를 가지려면
+        명시적 트랜잭션이 필요하므로 transaction.atomic() 으로 감싼다.
+        """
+        with transaction.atomic(), connection.cursor() as cursor:
             cursor.execute("SET LOCAL statement_timeout = 0")
             cursor.execute(
                 "SELECT drop_chunks(%s, older_than => NOW() - make_interval(months => %s))",
@@ -145,4 +149,9 @@ class Command(BaseCommand):
                 logger.warning("orm fallback: delete returned 0 — abort")
                 break
             orm_deleted += deleted
+        else:
+            logger.warning(
+                "orm fallback: max_iterations=%d reached without drain",
+                max_iterations,
+            )
         return orm_deleted

--- a/posts/management/commands/cleanup_old_stats.py
+++ b/posts/management/commands/cleanup_old_stats.py
@@ -79,4 +79,12 @@ class Command(BaseCommand):
             )
             return
 
-        self.stdout.write("would proceed (drop_chunks impl in next phase)")
+        with connection.cursor() as cursor:
+            cursor.execute("SET LOCAL statement_timeout = 0")
+            cursor.execute(
+                "SELECT drop_chunks(%s, older_than => NOW() - make_interval(months => %s))",
+                [HYPERTABLE_NAME, months],
+            )
+            dropped_rows = cursor.fetchall()
+        dropped_chunks = len(dropped_rows)
+        self.stdout.write(f"dropped {dropped_chunks} chunks")

--- a/posts/management/commands/cleanup_old_stats.py
+++ b/posts/management/commands/cleanup_old_stats.py
@@ -1,5 +1,8 @@
 """PostDailyStatistics 의 6개월 이전 데이터를 drop_chunks 로 정리하는 배치."""
 
+import logging
+import math
+from datetime import datetime
 from zoneinfo import ZoneInfo
 
 from django.core.management.base import BaseCommand
@@ -7,6 +10,8 @@ from django.db import connection
 from django.utils import timezone
 
 from posts.models import PostDailyStatistics
+
+logger = logging.getLogger(__name__)
 
 RETENTION_MONTHS_DEFAULT = 6
 ORM_CHUNK_DEFAULT = 5000
@@ -79,6 +84,14 @@ class Command(BaseCommand):
             )
             return
 
+        dropped_chunks, cutoff_ts = self._drop_chunks_and_get_cutoff(months)
+        orm_deleted = self._orm_fallback(cutoff_ts, chunk)
+        self.stdout.write(
+            f"dropped {dropped_chunks} chunks, {orm_deleted} orm rows"
+        )
+
+    def _drop_chunks_and_get_cutoff(self, months: int) -> tuple[int, datetime]:
+        """drop_chunks 호출 + cutoff_ts 산출. 동일 cursor 안에서 처리."""
         with connection.cursor() as cursor:
             cursor.execute("SET LOCAL statement_timeout = 0")
             cursor.execute(
@@ -86,5 +99,34 @@ class Command(BaseCommand):
                 [HYPERTABLE_NAME, months],
             )
             dropped_rows = cursor.fetchall()
-        dropped_chunks = len(dropped_rows)
-        self.stdout.write(f"dropped {dropped_chunks} chunks")
+            cursor.execute(
+                "SELECT NOW() - make_interval(months => %s)", [months]
+            )
+            cutoff_ts = cursor.fetchone()[0]
+        return len(dropped_rows), cutoff_ts
+
+    def _orm_fallback(self, cutoff_ts: datetime, chunk: int) -> int:
+        """drop_chunks 후 chunk 경계 안쪽 잔여 행을 ORM 으로 정리."""
+        remaining = PostDailyStatistics.objects.filter(
+            date__lt=cutoff_ts
+        ).count()
+        if remaining == 0:
+            return 0
+        max_iterations = math.ceil(remaining / chunk) + 10
+        orm_deleted = 0
+        for _ in range(max_iterations):
+            ids = list(
+                PostDailyStatistics.objects.filter(
+                    date__lt=cutoff_ts
+                ).values_list("pk", flat=True)[:chunk]
+            )
+            if not ids:
+                break
+            deleted, _ = PostDailyStatistics.objects.filter(
+                pk__in=ids
+            ).delete()
+            if deleted == 0:
+                logger.warning("orm fallback: delete returned 0 — abort")
+                break
+            orm_deleted += deleted
+        return orm_deleted

--- a/posts/management/commands/cleanup_old_stats.py
+++ b/posts/management/commands/cleanup_old_stats.py
@@ -79,9 +79,8 @@ class Command(BaseCommand):
             orm_deleted = self._orm_fallback(cutoff_ts, chunk)
         except Exception as e:
             logger.exception("cleanup_old_stats failed")
-            notify_ops(
+            self._notify_ops_safely(
                 text=f"[velog-dashboard-v2] PostDailyStatistics 정리 실패: {e}",
-                cooldown_key=COOLDOWN_KEY,
                 redis_client=redis_client,
             )
             raise CommandError(str(e)) from e
@@ -93,7 +92,7 @@ class Command(BaseCommand):
             orm_deleted,
             elapsed,
         )
-        notify_ops(
+        self._notify_ops_safely(
             text=(
                 f"[velog-dashboard-v2] PostDailyStatistics 정리 완료\n"
                 f"- cutoff: {cutoff_ts.isoformat()}\n"
@@ -101,12 +100,23 @@ class Command(BaseCommand):
                 f"- orm_deleted: {orm_deleted}\n"
                 f"- elapsed: {elapsed:.2f}s"
             ),
-            cooldown_key=COOLDOWN_KEY,
             redis_client=redis_client,
         )
         self.stdout.write(
             f"dropped {dropped_chunks} chunks, {orm_deleted} orm rows"
         )
+
+    @staticmethod
+    def _notify_ops_safely(text: str, redis_client) -> None:
+        """notify_ops 가 raise 해도 배치 결과가 오염되지 않도록 best-effort 래핑."""
+        try:
+            notify_ops(
+                text=text,
+                cooldown_key=COOLDOWN_KEY,
+                redis_client=redis_client,
+            )
+        except Exception:
+            logger.warning("notify_ops failed", exc_info=True)
 
     @staticmethod
     def _safe_redis_client():

--- a/posts/management/commands/cleanup_old_stats.py
+++ b/posts/management/commands/cleanup_old_stats.py
@@ -10,6 +10,8 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import connection, transaction
 from django.utils import timezone
 
+from modules.noti.slack_client import notify_ops
+from modules.redis.client import get_redis_client
 from posts.models import PostDailyStatistics
 
 logger = logging.getLogger(__name__)
@@ -86,6 +88,7 @@ class Command(BaseCommand):
             return
 
         started_at = time.monotonic()
+        redis_client = self._safe_redis_client()
         try:
             dropped_chunks, cutoff_ts = self._drop_chunks_and_get_cutoff(
                 months
@@ -93,6 +96,11 @@ class Command(BaseCommand):
             orm_deleted = self._orm_fallback(cutoff_ts, chunk)
         except Exception as e:
             logger.exception("cleanup_old_stats failed")
+            notify_ops(
+                text=f"[velog-dashboard-v2] PostDailyStatistics 정리 실패: {e}",
+                cooldown_key=COOLDOWN_KEY,
+                redis_client=redis_client,
+            )
             raise CommandError(str(e)) from e
         elapsed = time.monotonic() - started_at
         logger.info(
@@ -102,9 +110,29 @@ class Command(BaseCommand):
             orm_deleted,
             elapsed,
         )
+        notify_ops(
+            text=(
+                f"[velog-dashboard-v2] PostDailyStatistics 정리 완료\n"
+                f"- cutoff: {cutoff_ts.isoformat()}\n"
+                f"- dropped_chunks: {dropped_chunks}\n"
+                f"- orm_deleted: {orm_deleted}\n"
+                f"- elapsed: {elapsed:.2f}s"
+            ),
+            cooldown_key=COOLDOWN_KEY,
+            redis_client=redis_client,
+        )
         self.stdout.write(
             f"dropped {dropped_chunks} chunks, {orm_deleted} orm rows"
         )
+
+    @staticmethod
+    def _safe_redis_client():
+        """Redis 미가용 시 워닝만 남기고 None 반환 (배치는 계속)."""
+        try:
+            return get_redis_client()
+        except Exception as e:
+            logger.warning("redis unavailable: %s", e)
+            return None
 
     def _drop_chunks_and_get_cutoff(self, months: int) -> tuple[int, datetime]:
         """drop_chunks 호출 + cutoff_ts 산출.

--- a/posts/management/commands/cleanup_old_stats.py
+++ b/posts/management/commands/cleanup_old_stats.py
@@ -3,12 +3,16 @@
 from zoneinfo import ZoneInfo
 
 from django.core.management.base import BaseCommand
+from django.db import connection
 from django.utils import timezone
+
+from posts.models import PostDailyStatistics
 
 RETENTION_MONTHS_DEFAULT = 6
 ORM_CHUNK_DEFAULT = 5000
 COOLDOWN_KEY = "cleanup-old-stats"
 KST = ZoneInfo("Asia/Seoul")
+HYPERTABLE_NAME = "posts_postdailystatistics"
 
 
 class Command(BaseCommand):
@@ -53,6 +57,26 @@ class Command(BaseCommand):
             2,
         ):
             self.stdout.write("not the 1st/2nd of month KST, skipping")
+            return
+
+        if options["dry_run"]:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT NOW() - make_interval(months => %s)", [months]
+                )
+                cutoff_ts = cursor.fetchone()[0]
+                cursor.execute(
+                    "SELECT count(*) FROM show_chunks(%s, older_than => %s)",
+                    [HYPERTABLE_NAME, cutoff_ts],
+                )
+                chunk_count = cursor.fetchone()[0]
+            row_count = PostDailyStatistics.objects.filter(
+                date__lt=cutoff_ts
+            ).count()
+            self.stdout.write(
+                f"dry-run cutoff={cutoff_ts.isoformat()} "
+                f"chunks={chunk_count} rows~={row_count}"
+            )
             return
 
         self.stdout.write("would proceed (drop_chunks impl in next phase)")

--- a/posts/management/commands/cleanup_old_stats.py
+++ b/posts/management/commands/cleanup_old_stats.py
@@ -74,7 +74,7 @@ class Command(BaseCommand):
                 )
                 cutoff_ts = cursor.fetchone()[0]
                 cursor.execute(
-                    "SELECT count(*) FROM show_chunks(%s, older_than => %s)",
+                    "SELECT count(*) FROM show_chunks(%s::regclass, older_than => %s)",
                     [HYPERTABLE_NAME, cutoff_ts],
                 )
                 chunk_count = cursor.fetchone()[0]
@@ -139,18 +139,19 @@ class Command(BaseCommand):
 
         Django 기본 autocommit 환경에서 `SET LOCAL` 이 효과를 가지려면
         명시적 트랜잭션이 필요하므로 transaction.atomic() 으로 감싼다.
+        cutoff_ts 를 먼저 산출해 drop_chunks 와 ORM 폴백이 동일 시점을 공유.
         """
         with transaction.atomic(), connection.cursor() as cursor:
             cursor.execute("SET LOCAL statement_timeout = 0")
             cursor.execute(
-                "SELECT drop_chunks(%s, older_than => NOW() - make_interval(months => %s))",
-                [HYPERTABLE_NAME, months],
-            )
-            dropped_rows = cursor.fetchall()
-            cursor.execute(
                 "SELECT NOW() - make_interval(months => %s)", [months]
             )
             cutoff_ts = cursor.fetchone()[0]
+            cursor.execute(
+                "SELECT drop_chunks(%s::regclass, older_than => %s)",
+                [HYPERTABLE_NAME, cutoff_ts],
+            )
+            dropped_rows = cursor.fetchall()
         return len(dropped_rows), cutoff_ts
 
     def _orm_fallback(self, cutoff_ts: datetime, chunk: int) -> int:
@@ -160,7 +161,7 @@ class Command(BaseCommand):
         ).count()
         if remaining == 0:
             return 0
-        max_iterations = math.ceil(remaining / chunk) + 10
+        max_iterations = min(math.ceil(remaining / chunk) + 10, 1000)
         orm_deleted = 0
         for _ in range(max_iterations):
             ids = list(

--- a/posts/management/commands/cleanup_old_stats.py
+++ b/posts/management/commands/cleanup_old_stats.py
@@ -1,0 +1,58 @@
+"""PostDailyStatistics 의 6개월 이전 데이터를 drop_chunks 로 정리하는 배치."""
+
+from zoneinfo import ZoneInfo
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+RETENTION_MONTHS_DEFAULT = 6
+ORM_CHUNK_DEFAULT = 5000
+COOLDOWN_KEY = "cleanup-old-stats"
+KST = ZoneInfo("Asia/Seoul")
+
+
+class Command(BaseCommand):
+    help = "PostDailyStatistics 의 6개월 이전 데이터를 drop_chunks 로 정리."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--retention-months",
+            type=int,
+            default=RETENTION_MONTHS_DEFAULT,
+            help="보존 개월 수 (기본 6)",
+        )
+        parser.add_argument(
+            "--chunk",
+            type=int,
+            default=ORM_CHUNK_DEFAULT,
+            help="ORM 폴백 시 1회 DELETE chunk 크기",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="삭제 없이 대상만 출력",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="KST 1~2일 day-guard 우회 (수동 실행 전용)",
+        )
+
+    def handle(self, *args, **options) -> None:
+        months = options["retention_months"]
+        chunk = options["chunk"]
+        if months <= 0:
+            raise SystemExit(
+                f"--retention-months must be positive (got {months})"
+            )
+        if chunk <= 0:
+            raise SystemExit(f"--chunk must be positive (got {chunk})")
+
+        if not options["force"] and timezone.now().astimezone(KST).day not in (
+            1,
+            2,
+        ):
+            self.stdout.write("not the 1st/2nd of month KST, skipping")
+            return
+
+        self.stdout.write("would proceed (drop_chunks impl in next phase)")

--- a/posts/management/commands/cleanup_old_stats.py
+++ b/posts/management/commands/cleanup_old_stats.py
@@ -84,8 +84,14 @@ class Command(BaseCommand):
             )
             return
 
-        dropped_chunks, cutoff_ts = self._drop_chunks_and_get_cutoff(months)
-        orm_deleted = self._orm_fallback(cutoff_ts, chunk)
+        try:
+            dropped_chunks, cutoff_ts = self._drop_chunks_and_get_cutoff(
+                months
+            )
+            orm_deleted = self._orm_fallback(cutoff_ts, chunk)
+        except Exception as e:
+            logger.exception("cleanup_old_stats failed")
+            raise SystemExit(1) from e
         self.stdout.write(
             f"dropped {dropped_chunks} chunks, {orm_deleted} orm rows"
         )

--- a/posts/tests/conftest.py
+++ b/posts/tests/conftest.py
@@ -1,0 +1,40 @@
+"""posts 앱 공용 fixture."""
+
+import uuid
+from datetime import datetime
+
+import pytest
+
+from posts.models import Post, PostDailyStatistics
+from users.models import User
+
+
+@pytest.fixture
+def post_stats_factory(db):
+    """임의 date 의 PostDailyStatistics 를 생성하는 factory fixture."""
+
+    def _make(
+        date: datetime,
+        daily_view_count: int = 1,
+        daily_like_count: int = 0,
+        title: str = "factory",
+    ) -> PostDailyStatistics:
+        user = User.objects.create(
+            velog_uuid=uuid.uuid4(),
+            access_token="tok",
+            refresh_token="tok",
+        )
+        post = Post.objects.create(
+            post_uuid=uuid.uuid4(),
+            user=user,
+            title=title,
+            is_active=True,
+        )
+        return PostDailyStatistics.objects.create(
+            post=post,
+            date=date,
+            daily_view_count=daily_view_count,
+            daily_like_count=daily_like_count,
+        )
+
+    return _make

--- a/posts/tests/conftest.py
+++ b/posts/tests/conftest.py
@@ -1,5 +1,3 @@
-"""posts 앱 공용 fixture."""
-
 import uuid
 from datetime import datetime
 

--- a/posts/tests/test_cleanup_old_stats.py
+++ b/posts/tests/test_cleanup_old_stats.py
@@ -150,3 +150,18 @@ def test_drop_chunks_error_raises_system_exit():
     ):
         with pytest.raises(SystemExit):
             call_command("cleanup_old_stats", "--force")
+
+
+@pytest.mark.django_db
+def test_summary_log_contains_key_fields(caplog):
+    cutoff = timezone.now() - timedelta(days=180)
+    with (
+        patch(DROP_CHUNKS_HELPER, return_value=(3, cutoff)),
+        caplog.at_level(
+            "INFO", logger="posts.management.commands.cleanup_old_stats"
+        ),
+    ):
+        call_command("cleanup_old_stats", "--force")
+    log_text = " ".join(r.getMessage() for r in caplog.records)
+    for token in ("cutoff=", "dropped_chunks=", "orm_deleted="):
+        assert token in log_text, f"missing token: {token} in {log_text!r}"

--- a/posts/tests/test_cleanup_old_stats.py
+++ b/posts/tests/test_cleanup_old_stats.py
@@ -1,11 +1,14 @@
 """cleanup_old_stats management command 테스트."""
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from io import StringIO
 from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
+from django.utils import timezone
+
+from posts.models import PostDailyStatistics
 
 
 @pytest.mark.parametrize(
@@ -55,3 +58,16 @@ def test_force_bypasses_day_guard():
         out = StringIO()
         call_command("cleanup_old_stats", "--force", stdout=out)
         assert "skipping" not in out.getvalue().lower()
+
+
+@pytest.mark.django_db
+def test_dry_run_reports_summary_and_keeps_rows(post_stats_factory):
+    old_stats = post_stats_factory(date=timezone.now() - timedelta(days=200))
+    out = StringIO()
+    call_command("cleanup_old_stats", "--dry-run", "--force", stdout=out)
+    output = out.getvalue()
+    assert "cutoff=" in output
+    assert "chunks=" in output
+    assert "rows~=" in output
+    # dry-run 은 실제 행을 건드리지 않아야 함 (drop_chunks 미호출의 implicit 검증)
+    assert PostDailyStatistics.objects.filter(pk=old_stats.pk).exists()

--- a/posts/tests/test_cleanup_old_stats.py
+++ b/posts/tests/test_cleanup_old_stats.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.db.utils import ProgrammingError
 from django.utils import timezone
 
@@ -38,8 +39,8 @@ def _mock_cursor(fetchall_return=None, fetchone_return=None):
         ["--chunk", "-5"],
     ],
 )
-def test_invalid_args_raise_system_exit(args):
-    with pytest.raises(SystemExit):
+def test_invalid_args_raise_command_error(args):
+    with pytest.raises(CommandError):
         call_command("cleanup_old_stats", *args)
 
 
@@ -101,6 +102,7 @@ def test_dry_run_reports_summary_and_keeps_rows(post_stats_factory):
     assert PostDailyStatistics.objects.filter(pk=old_stats.pk).exists()
 
 
+@pytest.mark.django_db
 def test_drop_chunks_helper_uses_ts2_signature_and_statement_timeout():
     """helper 단위 검증 — call_command 거치지 않고 SQL 토큰만 확인."""
     fake_cm, fake_cursor = _mock_cursor()
@@ -134,21 +136,25 @@ def test_empty_table_runs_without_error():
 
 
 @pytest.mark.django_db
-def test_second_run_idempotent_after_first():
+def test_second_run_is_noop_after_cleanup(post_stats_factory):
+    """1차 실행 후 데이터 정리됨 → 2차 실행은 빈 ORM 폴백으로 정상 종료."""
+    old_stats = post_stats_factory(date=timezone.now() - timedelta(days=200))
     cutoff = timezone.now() - timedelta(days=180)
     with patch(DROP_CHUNKS_HELPER, return_value=(0, cutoff)):
         call_command("cleanup_old_stats", "--force")
+        assert not PostDailyStatistics.objects.filter(pk=old_stats.pk).exists()
+        # 2차 실행 — orm count = 0, exception 없이 종료
         call_command("cleanup_old_stats", "--force")
 
 
-def test_drop_chunks_error_raises_system_exit():
+def test_drop_chunks_error_raises_command_error():
     with patch(
         DROP_CHUNKS_HELPER,
         side_effect=ProgrammingError(
             "function drop_chunks(...) does not exist"
         ),
     ):
-        with pytest.raises(SystemExit):
+        with pytest.raises(CommandError):
             call_command("cleanup_old_stats", "--force")
 
 

--- a/posts/tests/test_cleanup_old_stats.py
+++ b/posts/tests/test_cleanup_old_stats.py
@@ -2,13 +2,24 @@
 
 from datetime import UTC, datetime, timedelta
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.management import call_command
 from django.utils import timezone
 
 from posts.models import PostDailyStatistics
+
+
+def _mock_cursor(fetchall_return=None, fetchone_return=None):
+    """connection.cursor() 컨텍스트 매니저 mock 헬퍼."""
+    fake_cm = MagicMock()
+    fake_cursor = fake_cm.__enter__.return_value
+    fake_cursor.fetchall.return_value = fetchall_return or []
+    fake_cursor.fetchone.return_value = fetchone_return or (
+        timezone.now() - timedelta(days=180),
+    )
+    return fake_cm, fake_cursor
 
 
 @pytest.mark.parametrize(
@@ -39,9 +50,16 @@ def test_invalid_args_raise_system_exit(args):
     ],
 )
 def test_day_guard_only_passes_on_kst_day_1_or_2(utc_dt, should_skip):
-    with patch(
-        "posts.management.commands.cleanup_old_stats.timezone.now",
-        return_value=utc_dt,
+    fake_cm, _ = _mock_cursor()
+    with (
+        patch(
+            "posts.management.commands.cleanup_old_stats.timezone.now",
+            return_value=utc_dt,
+        ),
+        patch(
+            "posts.management.commands.cleanup_old_stats.connection.cursor",
+            return_value=fake_cm,
+        ),
     ):
         out = StringIO()
         call_command("cleanup_old_stats", stdout=out)
@@ -51,9 +69,16 @@ def test_day_guard_only_passes_on_kst_day_1_or_2(utc_dt, should_skip):
 
 def test_force_bypasses_day_guard():
     # KST 16일 — guard 라면 skip 이지만 --force 는 우회해야 함
-    with patch(
-        "posts.management.commands.cleanup_old_stats.timezone.now",
-        return_value=datetime(2026, 5, 15, 19, 0, tzinfo=UTC),
+    fake_cm, _ = _mock_cursor()
+    with (
+        patch(
+            "posts.management.commands.cleanup_old_stats.timezone.now",
+            return_value=datetime(2026, 5, 15, 19, 0, tzinfo=UTC),
+        ),
+        patch(
+            "posts.management.commands.cleanup_old_stats.connection.cursor",
+            return_value=fake_cm,
+        ),
     ):
         out = StringIO()
         call_command("cleanup_old_stats", "--force", stdout=out)
@@ -71,3 +96,15 @@ def test_dry_run_reports_summary_and_keeps_rows(post_stats_factory):
     assert "rows~=" in output
     # dry-run 은 실제 행을 건드리지 않아야 함 (drop_chunks 미호출의 implicit 검증)
     assert PostDailyStatistics.objects.filter(pk=old_stats.pk).exists()
+
+
+def test_drop_chunks_called_with_ts2_signature_and_statement_timeout():
+    fake_cm, fake_cursor = _mock_cursor()
+    with patch(
+        "posts.management.commands.cleanup_old_stats.connection.cursor",
+        return_value=fake_cm,
+    ):
+        call_command("cleanup_old_stats", "--force")
+    executed = [str(c.args[0]) for c in fake_cursor.execute.mock_calls]
+    assert any("drop_chunks" in s and "older_than" in s for s in executed)
+    assert any("statement_timeout" in s for s in executed)

--- a/posts/tests/test_cleanup_old_stats.py
+++ b/posts/tests/test_cleanup_old_stats.py
@@ -199,6 +199,44 @@ def test_notify_ops_not_called_in_dry_run(
     assert not quiet_external_calls.called
 
 
+def test_default_retention_months_is_6():
+    """AC-2 — `--retention-months` 기본값 6."""
+    cmd = Command()
+    parser = cmd.create_parser("manage.py", "cleanup_old_stats")
+    ns = parser.parse_args([])
+    assert ns.retention_months == 6
+
+
+@pytest.mark.django_db
+def test_orm_fallback_aborts_when_delete_returns_zero(caplog):
+    """AC-10 zero-delete guard — delete 가 0 반환 시 break + warning."""
+    cmd = Command()
+    cutoff = timezone.now() - timedelta(days=180)
+    with patch(
+        "posts.management.commands.cleanup_old_stats.PostDailyStatistics.objects"
+    ) as mock_objects:
+        # filter().count() = 5, filter().values_list()[:N] = [1..5], filter().delete() = (0, {})
+        mock_qs = MagicMock()
+        mock_qs.count.return_value = 5
+        mock_qs.values_list.return_value.__getitem__.return_value = [
+            1,
+            2,
+            3,
+            4,
+            5,
+        ]
+        mock_qs.delete.return_value = (0, {})
+        mock_objects.filter.return_value = mock_qs
+        with caplog.at_level(
+            "WARNING", logger="posts.management.commands.cleanup_old_stats"
+        ):
+            result = cmd._orm_fallback(cutoff, chunk=5)
+    assert result == 0
+    assert any("delete returned 0" in r.getMessage() for r in caplog.records)
+    # delete 가 1번만 호출되고 break 되어야 함
+    assert mock_qs.delete.call_count == 1
+
+
 @pytest.mark.django_db
 def test_redis_unavailable_does_not_fail_batch(monkeypatch, caplog):
     """get_redis_client 가 예외를 raise 해도 배치는 정상 종료."""

--- a/posts/tests/test_cleanup_old_stats.py
+++ b/posts/tests/test_cleanup_old_stats.py
@@ -1,0 +1,57 @@
+"""cleanup_old_stats management command 테스트."""
+
+from datetime import UTC, datetime
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["--retention-months", "0"],
+        ["--retention-months", "-1"],
+        ["--chunk", "0"],
+        ["--chunk", "-5"],
+    ],
+)
+def test_invalid_args_raise_system_exit(args):
+    with pytest.raises(SystemExit):
+        call_command("cleanup_old_stats", *args)
+
+
+@pytest.mark.parametrize(
+    "utc_dt, should_skip",
+    [
+        # KST 16일 03:00 → skip
+        (datetime(2026, 5, 15, 19, 0, tzinfo=UTC), True),
+        # KST 1일 03:00 → 통과 (workflow_dispatch 시나리오)
+        (datetime(2026, 5, 31, 18, 0, tzinfo=UTC), False),
+        # KST 2일 04:00 (cron 발화) → 통과
+        (datetime(2026, 6, 1, 19, 0, tzinfo=UTC), False),
+        # KST 3일 03:00 → skip
+        (datetime(2026, 6, 2, 18, 0, tzinfo=UTC), True),
+    ],
+)
+def test_day_guard_only_passes_on_kst_day_1_or_2(utc_dt, should_skip):
+    with patch(
+        "posts.management.commands.cleanup_old_stats.timezone.now",
+        return_value=utc_dt,
+    ):
+        out = StringIO()
+        call_command("cleanup_old_stats", stdout=out)
+        skipped = "skipping" in out.getvalue().lower()
+        assert skipped is should_skip
+
+
+def test_force_bypasses_day_guard():
+    # KST 16일 — guard 라면 skip 이지만 --force 는 우회해야 함
+    with patch(
+        "posts.management.commands.cleanup_old_stats.timezone.now",
+        return_value=datetime(2026, 5, 15, 19, 0, tzinfo=UTC),
+    ):
+        out = StringIO()
+        call_command("cleanup_old_stats", "--force", stdout=out)
+        assert "skipping" not in out.getvalue().lower()

--- a/posts/tests/test_cleanup_old_stats.py
+++ b/posts/tests/test_cleanup_old_stats.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.management import call_command
+from django.db.utils import ProgrammingError
 from django.utils import timezone
 
 from posts.management.commands.cleanup_old_stats import Command
@@ -123,3 +124,29 @@ def test_orm_fallback_deletes_rows_below_cutoff(post_stats_factory):
         call_command("cleanup_old_stats", "--force")
     assert not PostDailyStatistics.objects.filter(pk=old_stats.pk).exists()
     assert PostDailyStatistics.objects.filter(pk=new_stats.pk).exists()
+
+
+@pytest.mark.django_db
+def test_empty_table_runs_without_error():
+    cutoff = timezone.now() - timedelta(days=180)
+    with patch(DROP_CHUNKS_HELPER, return_value=(0, cutoff)):
+        call_command("cleanup_old_stats", "--force")
+
+
+@pytest.mark.django_db
+def test_second_run_idempotent_after_first():
+    cutoff = timezone.now() - timedelta(days=180)
+    with patch(DROP_CHUNKS_HELPER, return_value=(0, cutoff)):
+        call_command("cleanup_old_stats", "--force")
+        call_command("cleanup_old_stats", "--force")
+
+
+def test_drop_chunks_error_raises_system_exit():
+    with patch(
+        DROP_CHUNKS_HELPER,
+        side_effect=ProgrammingError(
+            "function drop_chunks(...) does not exist"
+        ),
+    ):
+        with pytest.raises(SystemExit):
+            call_command("cleanup_old_stats", "--force")

--- a/posts/tests/test_cleanup_old_stats.py
+++ b/posts/tests/test_cleanup_old_stats.py
@@ -1,6 +1,4 @@
-"""cleanup_old_stats management command 테스트."""
-
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from io import StringIO
 from unittest.mock import MagicMock, patch
 
@@ -59,56 +57,11 @@ def test_invalid_args_raise_command_error(args):
         call_command("cleanup_old_stats", *args)
 
 
-@pytest.mark.parametrize(
-    "utc_dt, should_skip",
-    [
-        # KST 16일 03:00 → skip
-        (datetime(2026, 5, 15, 19, 0, tzinfo=UTC), True),
-        # KST 1일 03:00 → 통과 (workflow_dispatch 시나리오)
-        (datetime(2026, 5, 31, 18, 0, tzinfo=UTC), False),
-        # KST 2일 04:00 (cron 발화) → 통과
-        (datetime(2026, 6, 1, 19, 0, tzinfo=UTC), False),
-        # KST 3일 03:00 → skip
-        (datetime(2026, 6, 2, 18, 0, tzinfo=UTC), True),
-    ],
-)
-def test_day_guard_only_passes_on_kst_day_1_or_2(utc_dt, should_skip):
-    cutoff = timezone.now() - timedelta(days=180)
-    with (
-        patch(
-            "posts.management.commands.cleanup_old_stats.timezone.now",
-            return_value=utc_dt,
-        ),
-        patch(DROP_CHUNKS_HELPER, return_value=(0, cutoff)),
-        patch(ORM_FALLBACK_HELPER, return_value=0),
-    ):
-        out = StringIO()
-        call_command("cleanup_old_stats", stdout=out)
-        skipped = "skipping" in out.getvalue().lower()
-        assert skipped is should_skip
-
-
-def test_force_bypasses_day_guard():
-    # KST 16일 — guard 라면 skip 이지만 --force 는 우회해야 함
-    cutoff = timezone.now() - timedelta(days=180)
-    with (
-        patch(
-            "posts.management.commands.cleanup_old_stats.timezone.now",
-            return_value=datetime(2026, 5, 15, 19, 0, tzinfo=UTC),
-        ),
-        patch(DROP_CHUNKS_HELPER, return_value=(0, cutoff)),
-        patch(ORM_FALLBACK_HELPER, return_value=0),
-    ):
-        out = StringIO()
-        call_command("cleanup_old_stats", "--force", stdout=out)
-        assert "skipping" not in out.getvalue().lower()
-
-
 @pytest.mark.django_db
 def test_dry_run_reports_summary_and_keeps_rows(post_stats_factory):
     old_stats = post_stats_factory(date=timezone.now() - timedelta(days=200))
     out = StringIO()
-    call_command("cleanup_old_stats", "--dry-run", "--force", stdout=out)
+    call_command("cleanup_old_stats", "--dry-run", stdout=out)
     output = out.getvalue()
     assert "cutoff=" in output
     assert "chunks=" in output
@@ -138,7 +91,7 @@ def test_orm_fallback_deletes_rows_below_cutoff(post_stats_factory):
     new_stats = post_stats_factory(date=timezone.now() - timedelta(days=30))
     cutoff = timezone.now() - timedelta(days=180)
     with patch(DROP_CHUNKS_HELPER, return_value=(0, cutoff)):
-        call_command("cleanup_old_stats", "--force")
+        call_command("cleanup_old_stats")
     assert not PostDailyStatistics.objects.filter(pk=old_stats.pk).exists()
     assert PostDailyStatistics.objects.filter(pk=new_stats.pk).exists()
 
@@ -147,7 +100,7 @@ def test_orm_fallback_deletes_rows_below_cutoff(post_stats_factory):
 def test_empty_table_runs_without_error():
     cutoff = timezone.now() - timedelta(days=180)
     with patch(DROP_CHUNKS_HELPER, return_value=(0, cutoff)):
-        call_command("cleanup_old_stats", "--force")
+        call_command("cleanup_old_stats")
 
 
 @pytest.mark.django_db
@@ -156,10 +109,10 @@ def test_second_run_is_noop_after_cleanup(post_stats_factory):
     old_stats = post_stats_factory(date=timezone.now() - timedelta(days=200))
     cutoff = timezone.now() - timedelta(days=180)
     with patch(DROP_CHUNKS_HELPER, return_value=(0, cutoff)):
-        call_command("cleanup_old_stats", "--force")
+        call_command("cleanup_old_stats")
         assert not PostDailyStatistics.objects.filter(pk=old_stats.pk).exists()
         # 2차 실행 — orm count = 0, exception 없이 종료
-        call_command("cleanup_old_stats", "--force")
+        call_command("cleanup_old_stats")
 
 
 def test_drop_chunks_error_raises_command_error_and_notifies_failure(
@@ -172,7 +125,7 @@ def test_drop_chunks_error_raises_command_error_and_notifies_failure(
         ),
     ):
         with pytest.raises(CommandError):
-            call_command("cleanup_old_stats", "--force")
+            call_command("cleanup_old_stats")
     assert quiet_external_calls.called
     assert "실패" in quiet_external_calls.call_args.kwargs["text"]
 
@@ -181,7 +134,7 @@ def test_drop_chunks_error_raises_command_error_and_notifies_failure(
 def test_notify_ops_called_on_success(quiet_external_calls):
     cutoff = timezone.now() - timedelta(days=180)
     with patch(DROP_CHUNKS_HELPER, return_value=(0, cutoff)):
-        call_command("cleanup_old_stats", "--force")
+        call_command("cleanup_old_stats")
     assert quiet_external_calls.called
     assert (
         quiet_external_calls.call_args.kwargs["cooldown_key"]
@@ -195,7 +148,7 @@ def test_notify_ops_not_called_in_dry_run(
     post_stats_factory, quiet_external_calls
 ):
     post_stats_factory(date=timezone.now() - timedelta(days=200))
-    call_command("cleanup_old_stats", "--dry-run", "--force")
+    call_command("cleanup_old_stats", "--dry-run")
     assert not quiet_external_calls.called
 
 
@@ -251,7 +204,7 @@ def test_redis_unavailable_does_not_fail_batch(monkeypatch, caplog):
             "WARNING", logger="posts.management.commands.cleanup_old_stats"
         ),
     ):
-        call_command("cleanup_old_stats", "--force")
+        call_command("cleanup_old_stats")
     assert any("redis" in r.getMessage().lower() for r in caplog.records)
 
 
@@ -264,7 +217,7 @@ def test_summary_log_contains_key_fields(caplog):
             "INFO", logger="posts.management.commands.cleanup_old_stats"
         ),
     ):
-        call_command("cleanup_old_stats", "--force")
+        call_command("cleanup_old_stats")
     log_text = " ".join(r.getMessage() for r in caplog.records)
     for token in ("cutoff=", "dropped_chunks=", "orm_deleted="):
         assert token in log_text, f"missing token: {token} in {log_text!r}"

--- a/posts/tests/test_cleanup_old_stats.py
+++ b/posts/tests/test_cleanup_old_stats.py
@@ -191,6 +191,23 @@ def test_orm_fallback_aborts_when_delete_returns_zero(caplog):
 
 
 @pytest.mark.django_db
+def test_notify_ops_failure_does_not_taint_batch_result(
+    quiet_external_calls, caplog
+):
+    """notify_ops 가 raise 해도 성공 정리가 실패로 끝나지 않아야 한다."""
+    cutoff = timezone.now() - timedelta(days=180)
+    quiet_external_calls.side_effect = ConnectionError("slack down")
+    with (
+        patch(DROP_CHUNKS_HELPER, return_value=(0, cutoff)),
+        caplog.at_level(
+            "WARNING", logger="posts.management.commands.cleanup_old_stats"
+        ),
+    ):
+        call_command("cleanup_old_stats")
+    assert any("notify_ops failed" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.django_db
 def test_redis_unavailable_does_not_fail_batch(monkeypatch, caplog):
     """get_redis_client 가 예외를 raise 해도 배치는 정상 종료."""
     monkeypatch.setattr(

--- a/posts/tests/test_cleanup_old_stats.py
+++ b/posts/tests/test_cleanup_old_stats.py
@@ -8,7 +8,13 @@ import pytest
 from django.core.management import call_command
 from django.utils import timezone
 
+from posts.management.commands.cleanup_old_stats import Command
 from posts.models import PostDailyStatistics
+
+DROP_CHUNKS_HELPER = "posts.management.commands.cleanup_old_stats.Command._drop_chunks_and_get_cutoff"
+ORM_FALLBACK_HELPER = (
+    "posts.management.commands.cleanup_old_stats.Command._orm_fallback"
+)
 
 
 def _mock_cursor(fetchall_return=None, fetchone_return=None):
@@ -50,16 +56,14 @@ def test_invalid_args_raise_system_exit(args):
     ],
 )
 def test_day_guard_only_passes_on_kst_day_1_or_2(utc_dt, should_skip):
-    fake_cm, _ = _mock_cursor()
+    cutoff = timezone.now() - timedelta(days=180)
     with (
         patch(
             "posts.management.commands.cleanup_old_stats.timezone.now",
             return_value=utc_dt,
         ),
-        patch(
-            "posts.management.commands.cleanup_old_stats.connection.cursor",
-            return_value=fake_cm,
-        ),
+        patch(DROP_CHUNKS_HELPER, return_value=(0, cutoff)),
+        patch(ORM_FALLBACK_HELPER, return_value=0),
     ):
         out = StringIO()
         call_command("cleanup_old_stats", stdout=out)
@@ -69,16 +73,14 @@ def test_day_guard_only_passes_on_kst_day_1_or_2(utc_dt, should_skip):
 
 def test_force_bypasses_day_guard():
     # KST 16일 — guard 라면 skip 이지만 --force 는 우회해야 함
-    fake_cm, _ = _mock_cursor()
+    cutoff = timezone.now() - timedelta(days=180)
     with (
         patch(
             "posts.management.commands.cleanup_old_stats.timezone.now",
             return_value=datetime(2026, 5, 15, 19, 0, tzinfo=UTC),
         ),
-        patch(
-            "posts.management.commands.cleanup_old_stats.connection.cursor",
-            return_value=fake_cm,
-        ),
+        patch(DROP_CHUNKS_HELPER, return_value=(0, cutoff)),
+        patch(ORM_FALLBACK_HELPER, return_value=0),
     ):
         out = StringIO()
         call_command("cleanup_old_stats", "--force", stdout=out)
@@ -98,13 +100,26 @@ def test_dry_run_reports_summary_and_keeps_rows(post_stats_factory):
     assert PostDailyStatistics.objects.filter(pk=old_stats.pk).exists()
 
 
-def test_drop_chunks_called_with_ts2_signature_and_statement_timeout():
+def test_drop_chunks_helper_uses_ts2_signature_and_statement_timeout():
+    """helper 단위 검증 — call_command 거치지 않고 SQL 토큰만 확인."""
     fake_cm, fake_cursor = _mock_cursor()
     with patch(
         "posts.management.commands.cleanup_old_stats.connection.cursor",
         return_value=fake_cm,
     ):
-        call_command("cleanup_old_stats", "--force")
+        Command()._drop_chunks_and_get_cutoff(6)
     executed = [str(c.args[0]) for c in fake_cursor.execute.mock_calls]
     assert any("drop_chunks" in s and "older_than" in s for s in executed)
     assert any("statement_timeout" in s for s in executed)
+
+
+@pytest.mark.django_db
+def test_orm_fallback_deletes_rows_below_cutoff(post_stats_factory):
+    """helper mock + 실제 ORM fallback 동작 검증."""
+    old_stats = post_stats_factory(date=timezone.now() - timedelta(days=200))
+    new_stats = post_stats_factory(date=timezone.now() - timedelta(days=30))
+    cutoff = timezone.now() - timedelta(days=180)
+    with patch(DROP_CHUNKS_HELPER, return_value=(0, cutoff)):
+        call_command("cleanup_old_stats", "--force")
+    assert not PostDailyStatistics.objects.filter(pk=old_stats.pk).exists()
+    assert PostDailyStatistics.objects.filter(pk=new_stats.pk).exists()

--- a/posts/tests/test_cleanup_old_stats.py
+++ b/posts/tests/test_cleanup_old_stats.py
@@ -30,6 +30,21 @@ def _mock_cursor(fetchall_return=None, fetchone_return=None):
     return fake_cm, fake_cursor
 
 
+@pytest.fixture(autouse=True)
+def quiet_external_calls(monkeypatch):
+    """Slack/Redis 외부 호출 차단. notify mock 을 반환해 검증 가능."""
+    notify_mock = MagicMock()
+    monkeypatch.setattr(
+        "posts.management.commands.cleanup_old_stats.get_redis_client",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "posts.management.commands.cleanup_old_stats.notify_ops",
+        notify_mock,
+    )
+    return notify_mock
+
+
 @pytest.mark.parametrize(
     "args",
     [
@@ -147,7 +162,9 @@ def test_second_run_is_noop_after_cleanup(post_stats_factory):
         call_command("cleanup_old_stats", "--force")
 
 
-def test_drop_chunks_error_raises_command_error():
+def test_drop_chunks_error_raises_command_error_and_notifies_failure(
+    quiet_external_calls,
+):
     with patch(
         DROP_CHUNKS_HELPER,
         side_effect=ProgrammingError(
@@ -156,6 +173,48 @@ def test_drop_chunks_error_raises_command_error():
     ):
         with pytest.raises(CommandError):
             call_command("cleanup_old_stats", "--force")
+    assert quiet_external_calls.called
+    assert "실패" in quiet_external_calls.call_args.kwargs["text"]
+
+
+@pytest.mark.django_db
+def test_notify_ops_called_on_success(quiet_external_calls):
+    cutoff = timezone.now() - timedelta(days=180)
+    with patch(DROP_CHUNKS_HELPER, return_value=(0, cutoff)):
+        call_command("cleanup_old_stats", "--force")
+    assert quiet_external_calls.called
+    assert (
+        quiet_external_calls.call_args.kwargs["cooldown_key"]
+        == "cleanup-old-stats"
+    )
+    assert "정리 완료" in quiet_external_calls.call_args.kwargs["text"]
+
+
+@pytest.mark.django_db
+def test_notify_ops_not_called_in_dry_run(
+    post_stats_factory, quiet_external_calls
+):
+    post_stats_factory(date=timezone.now() - timedelta(days=200))
+    call_command("cleanup_old_stats", "--dry-run", "--force")
+    assert not quiet_external_calls.called
+
+
+@pytest.mark.django_db
+def test_redis_unavailable_does_not_fail_batch(monkeypatch, caplog):
+    """get_redis_client 가 예외를 raise 해도 배치는 정상 종료."""
+    monkeypatch.setattr(
+        "posts.management.commands.cleanup_old_stats.get_redis_client",
+        MagicMock(side_effect=ConnectionError("redis down")),
+    )
+    cutoff = timezone.now() - timedelta(days=180)
+    with (
+        patch(DROP_CHUNKS_HELPER, return_value=(0, cutoff)),
+        caplog.at_level(
+            "WARNING", logger="posts.management.commands.cleanup_old_stats"
+        ),
+    ):
+        call_command("cleanup_old_stats", "--force")
+    assert any("redis" in r.getMessage().lower() for r in caplog.records)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## 🔥 변경 사항
- 6개월 초과 데이터 정리 & 자동 정리 배치 추가
- 그에 따른 github, action base 자동 정리 배치 추가

## 🏷 관련 이슈
- X

## 📸 스크린샷 (UI 변경 시 필수)
- X

## 📌 체크리스트
- [x] 기능이 정상적으로 동작하는지 테스트 완료
- [x] 코드 스타일 가이드 준수 여부 확인
- [x] 관련 문서 업데이트 완료 (필요 시)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 오래된 통계 데이터 정리 프로세스 문서화 추가

* **New Features**
  * 6개월 이전 통계 데이터를 자동으로 정리하는 일일 스케줄 추가 (매일 KST 04:00)
  * 수동 실행 옵션 제공 (보존 기간 및 드라이런 모드 설정 가능)

* **Tests**
  * 통계 데이터 정리 기능 테스트 모듈 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Check-Data-Out/velog-dashboard-v2-back-office/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->